### PR TITLE
Disable ShrinkWrap pass

### DIFF
--- a/llvm/lib/CodeGen/ShrinkWrap.cpp
+++ b/llvm/lib/CodeGen/ShrinkWrap.cpp
@@ -919,6 +919,10 @@ bool ShrinkWrap::runOnMachineFunction(MachineFunction &MF) {
   if (skipFunction(MF.getFunction()) || MF.empty() || !isShrinkWrapEnabled(MF))
     return false;
 
+  // Insert prologue/epilogue for Hotspot VM in entry/return blocks.
+  if (MF.getFunction().getCallingConv() == CallingConv::Hotspot_JIT)
+    return false;
+
   LLVM_DEBUG(dbgs() << "**** Analysing " << MF.getName() << '\n');
 
   init(MF);


### PR DESCRIPTION
## Related issue(s):

issue #

## What this PR does / why we need it:
Prologue/epilogue for Hotspot VM is only allowed in entry/return blocks.
