### PR TITLE
fix: disable ShrinkWrap for jeandle

### DIFF
--- a/llvm/lib/CodeGen/ShrinkWrap.cpp
+++ b/llvm/lib/CodeGen/ShrinkWrap.cpp
@@ -73,6 +73,7 @@
 #include "llvm/CodeGen/TargetRegisterInfo.h"
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
 #include "llvm/IR/Attributes.h"
+#include "llvm/IR/CallingConv.h"
 #include "llvm/IR/Function.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/MC/MCAsmInfo.h"
@@ -918,6 +919,10 @@ bool ShrinkWrap::performShrinkWrapping(
 bool ShrinkWrap::runOnMachineFunction(MachineFunction &MF) {
   if (skipFunction(MF.getFunction()) || MF.empty() || !isShrinkWrapEnabled(MF))
     return false;
+
+  if (MF.getFunction().getCallingConv() == CallingConv::Hotspot_JIT) {
+    return false;
+  }
 
   LLVM_DEBUG(dbgs() << "**** Analysing " << MF.getName() << '\n');
 

--- a/llvm/lib/CodeGen/ShrinkWrap.cpp
+++ b/llvm/lib/CodeGen/ShrinkWrap.cpp
@@ -1,5 +1,7 @@
 //===- ShrinkWrap.cpp - Compute safe point for prolog/epilog insertion ----===//
 //
+// Copyright (c) 2025, the Jeandle-LLVM Authors. All Rights Reserved.
+//
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception


### PR DESCRIPTION
## Related issue(s):

issue #

## What this PR does / why we need it:
ShrinkWrap moves the epilog and prolog away from the functino's entry and exit. This shift can result in issues where rbp, used temporarily to store the return value, is overwritten by the pop instruction in epilog, corrupting the return value.
