### PR TITLE
feat: Initial support for AArch64

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64CallingConvention.h
+++ b/llvm/lib/Target/AArch64/AArch64CallingConvention.h
@@ -65,6 +65,9 @@ bool RetCC_AArch64_Arm64EC_CFGuard_Check(unsigned ValNo, MVT ValVT, MVT LocVT,
                                          CCValAssign::LocInfo LocInfo,
                                          ISD::ArgFlagsTy ArgFlags,
                                          CCState &State);
+bool CC_AArch64_Hotspot(unsigned ValNo, MVT ValVT, MVT LocVT,
+                        CCValAssign::LocInfo LocInfo, ISD::ArgFlagsTy ArgFlags,
+                        CCState &State);
 } // namespace llvm
 
 #endif

--- a/llvm/lib/Target/AArch64/AArch64CallingConvention.td
+++ b/llvm/lib/Target/AArch64/AArch64CallingConvention.td
@@ -553,6 +553,40 @@ def CC_AArch64_Preserve_None : CallingConv<[
   CCDelegateTo<CC_AArch64_AAPCS>
 ]>;
 
+//===----------------------------------------------------------------------===//
+// ARM64 Calling Convention for OpenJDK HotSpot
+//===----------------------------------------------------------------------===//
+
+// This calling convention is specific to the OpenJDK HotSpot JIT Compiler.
+// The only documentation is the OpenJDK source code, specifically the C header
+// file:
+//
+//    https://github.com/jeandle/jeandle-jdk/blob/main/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+//
+// which defines the registers for the Java calling convention.
+//
+//  |--------------------------------------------------------------------|
+//  | X0       X1       X2      X3      X4      X5      X6      X7       |
+//  |--------------------------------------------------------------------|
+//  | c_rarg0  c_rarg1  c_rarg2 c_rarg3 c_rarg4 c_rarg5 c_rarg6 c_rarg7  |
+//  |--------------------------------------------------------------------|
+//  | j_rarg7  j_rarg0  j_rarg1 j_rarg2 j_rarg3 j_rarg4 j_rarg5 j_rarg6  |
+//  |--------------------------------------------------------------------|
+//
+
+let Entry = 1 in
+def CC_AArch64_Hotspot : CallingConv<[
+  CCIfType<[i32], CCAssignToReg<[W1, W2, W3, W4, W5, W6, W7, W0]>>,
+  CCIfType<[i64], CCAssignToReg<[X1, X2, X3, X4, X5, X6, X7, X0]>>,
+
+  // Java floating args are passed as per C
+  CCIfType<[f32], CCAssignToReg<[S0, S1, S2, S3, S4, S5, S6, S7]>>,
+  CCIfType<[f64], CCAssignToReg<[D0, D1, D2, D3, D4, D5, D6, D7]>>,
+
+  // Delegate to AAPCS for now
+  CCDelegateTo<CC_AArch64_AAPCS>
+]>;
+
 // The order of the callee-saves in this file is important, because the
 // FrameLowering code will use this order to determine the layout the
 // callee-save area in the stack frame. As can be observed below, Darwin
@@ -690,6 +724,12 @@ def CSR_AArch64_StackProbe_Windows
     : CalleeSavedRegs<(add (sequence "X%u", 0, 15),
                            (sequence "X%u", 18, 28), FP, SP,
                            (sequence "Q%u", 0, 31))>;
+
+// HotSpot C1/C2 compiler don't use any callee save registers.
+//   X0-X7,X10-X26 volatile (caller save)
+//   X27-X32 system (no save, no allocate)
+//   X8-X9 non-allocatable (so we can use them as scratch regs)
+def CSR_AArch64_Hotspot : CalleeSavedRegs<(add LR, FP)>;
 
 // Darwin variants of AAPCS.
 // Darwin puts the frame-record at the top of the callee-save area.

--- a/llvm/lib/Target/AArch64/AArch64FastISel.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FastISel.cpp
@@ -337,6 +337,8 @@ static unsigned getImplicitScaleFactor(MVT VT) {
 CCAssignFn *AArch64FastISel::CCAssignFnForCall(CallingConv::ID CC) const {
   if (CC == CallingConv::GHC)
     return CC_AArch64_GHC;
+  if (CC == CallingConv::Hotspot_JIT)
+    return CC_AArch64_Hotspot;
   if (CC == CallingConv::CFGuard_Check)
     return CC_AArch64_Win64_CFGuard_Check;
   if (Subtarget->isTargetDarwin())

--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -3675,6 +3675,15 @@ void AArch64FrameLowering::determineCalleeSaves(MachineFunction &MF,
   MachineFrameInfo &MFI = MF.getFrameInfo();
   const MCPhysReg *CSRegs = MF.getRegInfo().getCalleeSavedRegs();
 
+  // Hotspot always save LR & FP for stack unwinding
+  if (MF.getFunction().getCallingConv() == CallingConv::Hotspot_JIT) {
+    if (!SavedRegs.test(AArch64::FP))
+      SavedRegs.set(AArch64::FP);
+
+    if (!SavedRegs.test(AArch64::LR))
+      SavedRegs.set(AArch64::LR);
+  }
+
   unsigned BasePointerReg = RegInfo->hasBasePointer(MF)
                                 ? RegInfo->getBaseRegister()
                                 : (unsigned)AArch64::NoRegister;

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -1205,7 +1205,7 @@ AArch64TargetLowering::AArch64TargetLowering(const TargetMachine &TM,
           ISD::FSIN,              ISD::FCOS,           ISD::FTAN,
           ISD::FASIN,             ISD::FACOS,          ISD::FATAN,
           ISD::FSINH,             ISD::FCOSH,          ISD::FTANH,
-          ISD::FPOW,              ISD::FLOG,           ISD::FLOG2,          
+          ISD::FPOW,              ISD::FLOG,           ISD::FLOG2,
           ISD::FLOG10,            ISD::FEXP,           ISD::FEXP2,
           ISD::FEXP10,            ISD::FRINT,          ISD::FROUND,
           ISD::FROUNDEVEN,        ISD::FTRUNC,         ISD::FMINNUM,
@@ -1214,7 +1214,7 @@ AArch64TargetLowering::AArch64TargetLowering(const TargetMachine &TM,
           ISD::STRICT_FADD,       ISD::STRICT_FSUB,    ISD::STRICT_FMUL,
           ISD::STRICT_FDIV,       ISD::STRICT_FMA,     ISD::STRICT_FCEIL,
           ISD::STRICT_FFLOOR,     ISD::STRICT_FSQRT,   ISD::STRICT_FRINT,
-          ISD::STRICT_FNEARBYINT, ISD::STRICT_FROUND,  ISD::STRICT_FTRUNC,  
+          ISD::STRICT_FNEARBYINT, ISD::STRICT_FROUND,  ISD::STRICT_FTRUNC,
           ISD::STRICT_FROUNDEVEN, ISD::STRICT_FMINNUM, ISD::STRICT_FMAXNUM,
           ISD::STRICT_FMINIMUM,   ISD::STRICT_FMAXIMUM})
       setOperationAction(Op, MVT::v1f64, Expand);
@@ -7800,6 +7800,8 @@ CCAssignFn *AArch64TargetLowering::CCAssignFnForCall(CallingConv::ID CC,
     return CC_AArch64_Arm64EC_Thunk;
   case CallingConv::ARM64EC_Thunk_Native:
     return CC_AArch64_Arm64EC_Thunk_Native;
+  case CallingConv::Hotspot_JIT:
+    return CC_AArch64_Hotspot;
   }
 }
 


### PR DESCRIPTION
## Related issue(s):

issue #14 

## What this PR does / why we need it:

WIP

Hi team, please consider.
This PR contains initial support for the linux-aarch64 platform. The major changes are:
1. Add a new Java calling convention named `CC_AArch64_Hotspot`, including function args assignment convention and callee-saved register list.
2. Even if we set `FP` and `LR` as callee-saved registers, `TargetFrameLowering::determineCalleeSaves` may treat `FP` as a non-saved register when `MRI.isPhysRegModified(Reg)` returns `false` (which means `FP` was not modified across the calls, maybe?). To make stack unwinding correct, we should save `FP` manually.

Testing:
- [x] jeandle-jdk tier1_compiler_jeandle with linux-aarch64 slowdebug build
- [ ] jeandle-jdk tier1_compiler_jeandle with linux-aarch64 release build