### PR TITLE
refactor: Reimplement inline cache call alignment

### DIFF
--- a/llvm/include/llvm/MC/MCFragment.h
+++ b/llvm/include/llvm/MC/MCFragment.h
@@ -1,7 +1,5 @@
 //===- MCFragment.h - Fragment type hierarchy -------------------*- C++ -*-===//
 //
-// Copyright (c) 2025, the Jeandle-LLVM Authors. All Rights Reserved.
-//
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -16,7 +14,6 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/ilist_node.h"
-#include "llvm/MC/MCAsmBackend.h"
 #include "llvm/MC/MCFixup.h"
 #include "llvm/MC/MCInst.h"
 #include "llvm/Support/Alignment.h"
@@ -53,7 +50,6 @@ public:
     FT_CVInlineLines,
     FT_CVDefRange,
     FT_PseudoProbe,
-    FT_HotspotPatchPoint,
     FT_Dummy
   };
 
@@ -296,42 +292,6 @@ public:
 
   static bool classof(const MCFragment *F) {
     return F->getKind() == MCFragment::FT_Align;
-  }
-};
-
-/// Used for statepoint to support MT-safe code patch point in hotspot.
-/// Only used for X86-64 backends.
-/// For X86-64 backends, to support MT-safe code patch, hotspot requires
-/// patch address to be 4-bytes aligned, so the patch point can lie within
-/// a single cache line and patch operation can simply rely on atomicity
-/// of 32-bit writes.
-/// A patch point ends up with a pc-relative call instruction. The size of
-/// the instruction is 5 bytes and the call destination (displacement)
-/// occupies the last 4 bytes. Should garantee the displacement is 4-bytes
-/// aligned.
-class MCHotspotPatchPointFragment : public MCFragment {
-private:
-  /// When emitting Nops some subtargets have specific nop encodings.
-  const MCSubtargetInfo *STI = nullptr;
-
-  /// Displacement should be 4-bytes aligned.
-  const Align Alignment = Align(4);
-
-  const unsigned Size;
-
-public:
-  /// Size of a pc-relative call intruction.
-  static const unsigned CallSize = 5;
-
-  MCHotspotPatchPointFragment(const MCSubtargetInfo *STI, unsigned Size)
-      : MCFragment(FT_HotspotPatchPoint, false), STI(STI), Size(Size) {}
-
-  unsigned getSize(unsigned Offset) const;
-
-  void emit(MCAsmBackend &MAB, raw_ostream &OS, unsigned Offset) const;
-
-  static bool classof(const MCFragment *F) {
-    return F->getKind() == FT_HotspotPatchPoint;
   }
 };
 

--- a/llvm/include/llvm/MC/MCObjectStreamer.h
+++ b/llvm/include/llvm/MC/MCObjectStreamer.h
@@ -1,7 +1,5 @@
 //===- MCObjectStreamer.h - MCStreamer Object File Interface ----*- C++ -*-===//
 //
-// Copyright (c) 2025, the Jeandle-LLVM Authors. All Rights Reserved.
-//
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -139,8 +137,6 @@ public:
                             unsigned MaxBytesToEmit = 0) override;
   void emitCodeAlignment(Align ByteAlignment, const MCSubtargetInfo *STI,
                          unsigned MaxBytesToEmit = 0) override;
-  void emitHotspotPatchPoint(const MCSubtargetInfo *STI,
-                             unsigned PatchBytes) override;
   void emitValueToOffset(const MCExpr *Offset, unsigned char Value,
                          SMLoc Loc) override;
   void emitDwarfLocDirective(unsigned FileNo, unsigned Line, unsigned Column,

--- a/llvm/include/llvm/MC/MCStreamer.h
+++ b/llvm/include/llvm/MC/MCStreamer.h
@@ -1,7 +1,5 @@
 //===- MCStreamer.h - High-level Streaming Machine Code Output --*- C++ -*-===//
 //
-// Copyright (c) 2025, the Jeandle-LLVM Authors. All Rights Reserved.
-//
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -861,9 +859,6 @@ public:
   /// emitted.
   virtual void emitCodeAlignment(Align Alignment, const MCSubtargetInfo *STI,
                                  unsigned MaxBytesToEmit = 0);
-
-  virtual void emitHotspotPatchPoint(const MCSubtargetInfo *STI,
-                                     unsigned PatchBytes);
 
   /// Emit some number of copies of \p Value until the byte offset \p
   /// Offset is reached.

--- a/llvm/lib/MC/MCAssembler.cpp
+++ b/llvm/lib/MC/MCAssembler.cpp
@@ -1,7 +1,5 @@
 //===- lib/MC/MCAssembler.cpp - Assembler Backend Implementation ----------===//
 //
-// Copyright (c) 2025, the Jeandle-LLVM Authors. All Rights Reserved.
-//
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -335,14 +333,6 @@ uint64_t MCAssembler::computeFragmentSize(const MCFragment &F) const {
     return cast<MCCVDefRangeFragment>(F).getContents().size();
   case MCFragment::FT_PseudoProbe:
     return cast<MCPseudoProbeAddrFragment>(F).getContents().size();
-
-  case MCFragment::FT_HotspotPatchPoint: {
-    const MCHotspotPatchPointFragment &HF =
-        cast<MCHotspotPatchPointFragment>(F);
-    unsigned Offset = getFragmentOffset(HF);
-    return HF.getSize(Offset);
-  }
-
   case MCFragment::FT_Dummy:
     llvm_unreachable("Should not have been added");
   }
@@ -812,13 +802,6 @@ static void writeFragment(raw_ostream &OS, const MCAssembler &Asm,
   case MCFragment::FT_PseudoProbe: {
     const MCPseudoProbeAddrFragment &PF = cast<MCPseudoProbeAddrFragment>(F);
     OS << PF.getContents();
-    break;
-  }
-  case MCFragment::FT_HotspotPatchPoint: {
-    const MCHotspotPatchPointFragment &HF =
-        cast<MCHotspotPatchPointFragment>(F);
-    unsigned Offset = Asm.getFragmentOffset(HF);
-    HF.emit(Asm.getBackend(), OS, Offset);
     break;
   }
   case MCFragment::FT_Dummy:

--- a/llvm/lib/MC/MCFragment.cpp
+++ b/llvm/lib/MC/MCFragment.cpp
@@ -1,7 +1,5 @@
 //===- lib/MC/MCFragment.cpp - Assembler Fragment Implementation ----------===//
 //
-// Copyright (c) 2025, the Jeandle-LLVM Authors. All Rights Reserved.
-//
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -74,9 +72,6 @@ void MCFragment::destroy() {
     case FT_PseudoProbe:
       cast<MCPseudoProbeAddrFragment>(this)->~MCPseudoProbeAddrFragment();
       return;
-    case FT_HotspotPatchPoint:
-      delete cast<MCHotspotPatchPointFragment>(this);
-      return;
     case FT_Dummy:
       cast<MCDummyFragment>(this)->~MCDummyFragment();
       return;
@@ -123,9 +118,6 @@ LLVM_DUMP_METHOD void MCFragment::dump() const {
   case MCFragment::FT_CVDefRange: OS << "MCCVDefRangeTableFragment"; break;
   case MCFragment::FT_PseudoProbe:
     OS << "MCPseudoProbe";
-    break;
-  case MCFragment::FT_HotspotPatchPoint:
-    OS << "FT_HotspotPatchPoint";
     break;
   case MCFragment::FT_Dummy: OS << "MCDummyFragment"; break;
   }
@@ -249,32 +241,9 @@ LLVM_DUMP_METHOD void MCFragment::dump() const {
     OS << " AddrDelta:" << OF->getAddrDelta();
     break;
   }
-  case MCFragment::FT_HotspotPatchPoint: {
-    OS << "\n       ";
-    break;
-  }
   case MCFragment::FT_Dummy:
     break;
   }
   OS << ">";
 }
 #endif
-
-unsigned MCHotspotPatchPointFragment::getSize(unsigned Offset) const {
-  return alignTo(Size + Offset % Alignment.value(), Alignment) -
-         Offset % Alignment.value();
-}
-
-void MCHotspotPatchPointFragment::emit(MCAsmBackend &MAB, raw_ostream &OS,
-                                       unsigned Offset) const {
-  if (getSize(Offset) - Size > 0 &&
-      !MAB.writeNopData(OS, getSize(Offset) - Size, STI)) {
-    report_fatal_error("unable to write nop sequence of " +
-                       Twine(getSize(Offset) - Size) + " bytes");
-  }
-
-  if (!MAB.writeNopData(OS, Size, STI)) {
-    report_fatal_error("unable to write nop sequence of " + Twine(Size) +
-                       " bytes");
-  }
-}

--- a/llvm/lib/MC/MCObjectStreamer.cpp
+++ b/llvm/lib/MC/MCObjectStreamer.cpp
@@ -1,7 +1,5 @@
 //===- lib/MC/MCObjectStreamer.cpp - Object File MCStreamer Interface -----===//
 //
-// Copyright (c) 2025, the Jeandle-LLVM Authors. All Rights Reserved.
-//
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -575,11 +573,6 @@ void MCObjectStreamer::emitCodeAlignment(Align Alignment,
                                          unsigned MaxBytesToEmit) {
   emitValueToAlignment(Alignment, 0, 1, MaxBytesToEmit);
   cast<MCAlignFragment>(getCurrentFragment())->setEmitNops(true, STI);
-}
-
-void MCObjectStreamer::emitHotspotPatchPoint(const MCSubtargetInfo *STI,
-                                             unsigned PatchBytes) {
-  insert(new MCHotspotPatchPointFragment(STI, PatchBytes));
 }
 
 void MCObjectStreamer::emitValueToOffset(const MCExpr *Offset,

--- a/llvm/lib/MC/MCStreamer.cpp
+++ b/llvm/lib/MC/MCStreamer.cpp
@@ -1,7 +1,5 @@
 //===- lib/MC/MCStreamer.cpp - Streaming Machine Code Output --------------===//
 //
-// Copyright (c) 2025, the Jeandle-LLVM Authors. All Rights Reserved.
-//
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -1280,8 +1278,6 @@ void MCStreamer::emitValueToAlignment(Align Alignment, int64_t Value,
                                       unsigned MaxBytesToEmit) {}
 void MCStreamer::emitCodeAlignment(Align Alignment, const MCSubtargetInfo *STI,
                                    unsigned MaxBytesToEmit) {}
-void MCStreamer::emitHotspotPatchPoint(const MCSubtargetInfo *STI,
-                                       unsigned PatchBytes) {}
 void MCStreamer::emitValueToOffset(const MCExpr *Offset, unsigned char Value,
                                    SMLoc Loc) {}
 void MCStreamer::emitBundleAlignMode(Align Alignment) {}

--- a/llvm/test/Jeandle/X86/call-site-align.ll
+++ b/llvm/test/Jeandle/X86/call-site-align.ll
@@ -1,8 +1,10 @@
-; RUN: llc -O0 -mtriple=x86_64-linux-gnu -filetype=obj -o - %s | llvm-objdump -d - | FileCheck %s
+; RUN: llc -O0 -mtriple=x86_64-linux-gnu -o - %s | FileCheck %s
 
 define hotspotcc i32 @"Main_caller_()I"() local_unnamed_addr #0 gc "hotspotgc" {
-; CHECK: 10: 0f 1f 00 nopl (%rax)
-; CHECK-NEXT: 13: 0f 1f 44 00 00 nopl (%rax,%rax)
+; CHECK: # implicit-def: $rax
+; CHECK:	.p2align	2
+; CHECK:	nopl	(%rax)
+; CHECK:	nopl	8(%rax,%rax)
 entry:
   %statepoint_token = tail call hotspotcc token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 0, i32 5, ptr elementtype(i32 (i32, i32, i32)) @"Main_callee_(III)I", i32 3, i32 0, i32 1, i32 2, i32 3, i32 0, i32 0)
   %0 = call i32 @llvm.experimental.gc.result.i32(token %statepoint_token)


### PR DESCRIPTION
## Related issue(s):

issue #13

## What this PR does / why we need it:
Using normal align instructions and nops is more clearly.