### PR TITLE
enhance: Optimization of Const Global load in Jeandle

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64.h
+++ b/llvm/lib/Target/AArch64/AArch64.h
@@ -57,6 +57,8 @@ FunctionPass *createAArch64PostCoalescerPass();
 
 FunctionPass *createAArch64CleanupLocalDynamicTLSPass();
 
+FunctionPass *createAArch64JeandleOptLoadGlobalPass();
+
 FunctionPass *createAArch64CollectLOHPass();
 FunctionPass *createSMEABIPass();
 FunctionPass *createSMEPeepholeOptPass();
@@ -88,6 +90,7 @@ void initializeAArch64ConditionalComparesPass(PassRegistry &);
 void initializeAArch64DAGToDAGISelLegacyPass(PassRegistry &);
 void initializeAArch64DeadRegisterDefinitionsPass(PassRegistry&);
 void initializeAArch64ExpandPseudoPass(PassRegistry &);
+void initializeAArch64JeandleOptLoadGlobalPass(PassRegistry &);
 void initializeAArch64LoadStoreOptPass(PassRegistry&);
 void initializeAArch64LowerHomogeneousPrologEpilogPass(PassRegistry &);
 void initializeAArch64MIPeepholeOptPass(PassRegistry &);

--- a/llvm/lib/Target/AArch64/AArch64JeandleOptLoadGlobal.cpp
+++ b/llvm/lib/Target/AArch64/AArch64JeandleOptLoadGlobal.cpp
@@ -1,0 +1,132 @@
+//===- AArch64JeandleOptLoadGlobal.cpp - optimization of load global ------===//
+//
+// Copyright (c) 2025, the Jeandle-LLVM Authors. All Rights Reserved.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the pass that optimizes loads of specially-marked
+// global variables. For any instruction of the form:
+//     adrp  xDst, GV
+//     ldr   xDst, [xDst, #:lo12:GV]
+// where GV has metadata "jeandle.oop.handle", replaces it with:
+//     movz  xDst, #:abs_g0:GV
+//     movk  xDst, #:abs_g1:GV, lsl #16
+//     movk  xDst, #:abs_g2:GV, lsl #32
+// Safe in Jeandle: JeandleVM rewrites such oop handles into real
+// object references (oops) and continuously maintains them at
+// runtime to guarantee correctness and garbage-collection safety.
+//
+//===----------------------------------------------------------------------===//
+
+#include "AArch64.h"
+#include "AArch64InstrInfo.h"
+#include "AArch64MachineFunctionInfo.h"
+#include "AArch64Subtarget.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/IR/GlobalVariable.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm/Support/Debug.h"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "aarch64-jeandle-opt-load-global"
+
+namespace {
+
+class AArch64JeandleOptLoadGlobal : public MachineFunctionPass {
+public:
+  static char ID;
+  AArch64JeandleOptLoadGlobal() : MachineFunctionPass(ID) {}
+
+  StringRef getPassName() const override {
+    return "AArch64 Jeandle Opt Load Global";
+  }
+
+  bool runOnMachineFunction(MachineFunction &MF) override {
+    if (MF.getFunction().isDeclaration())
+      return false;
+
+    const AArch64Subtarget &STI = MF.getSubtarget<AArch64Subtarget>();
+    const AArch64InstrInfo *TII = STI.getInstrInfo();
+    bool Changed = false;
+
+    for (MachineBasicBlock &MBB : MF) {
+      for (auto I = MBB.begin(), E = MBB.end(); I != E;) {
+        MachineInstr &AdrpMI = *I;
+        ++I; // Iterate safely: increment before possibly erasing current instr.
+
+        if (AdrpMI.getOpcode() != AArch64::ADRP)
+          continue;
+
+        const MachineOperand &AdrpDst = AdrpMI.getOperand(0);
+        const MachineOperand &AdrpSym = AdrpMI.getOperand(1);
+        if (!AdrpSym.isGlobal())
+          continue;
+
+        // Only optimize globals marked with custom metadata.
+        const GlobalVariable *GV =
+            dyn_cast<GlobalVariable>(AdrpSym.getGlobal());
+        if (!GV || !GV->getMetadata("jeandle.oop.handle"))
+          continue;
+
+        // Check next MachineInstr
+        if (I == E)
+          continue;
+
+        MachineInstr &LdrMI = *I;
+        if (LdrMI.getOpcode() != AArch64::LDRXui)
+          continue;
+
+        const MachineOperand &LdrDst = LdrMI.getOperand(0);
+        const MachineOperand &LdrBase = LdrMI.getOperand(1);
+        const MachineOperand &LdrOffset = LdrMI.getOperand(2);
+
+        if (LdrBase.getReg() != AdrpDst.getReg() || !LdrOffset.isGlobal() ||
+            LdrOffset.getGlobal() != GV)
+          continue;
+
+        Register DstReg = LdrDst.getReg();
+        DebugLoc DL = AdrpMI.getDebugLoc();
+
+        // Load 48-bit absolute address of GV using:
+        //   movz xDst, #:abs_g0:GV            // bits 0-15
+        //   movk xDst, #:abs_g1:GV, lsl #16   // bits 16-31
+        //   movk xDst, #:abs_g2:GV, lsl #32   // bits 32-47
+        BuildMI(MBB, AdrpMI, DL, TII->get(AArch64::MOVZXi), DstReg)
+            .addGlobalAddress(GV, 0, AArch64II::MO_G0 | AArch64II::MO_NC)
+            .addImm(0);
+        BuildMI(MBB, AdrpMI, DL, TII->get(AArch64::MOVKXi), DstReg)
+            .addReg(DstReg)
+            .addGlobalAddress(GV, 0, AArch64II::MO_G1 | AArch64II::MO_NC)
+            .addImm(16);
+        BuildMI(MBB, AdrpMI, DL, TII->get(AArch64::MOVKXi), DstReg)
+            .addReg(DstReg)
+            .addGlobalAddress(GV, 0, AArch64II::MO_G2 | AArch64II::MO_NC)
+            .addImm(32);
+
+        ++I;
+        AdrpMI.eraseFromParent();
+        LdrMI.eraseFromParent();
+        Changed = true;
+      }
+    }
+    return Changed;
+  }
+};
+
+} // end anonymous namespace
+
+char AArch64JeandleOptLoadGlobal::ID = 0;
+
+FunctionPass *llvm::createAArch64JeandleOptLoadGlobalPass() {
+  return new AArch64JeandleOptLoadGlobal();
+}
+
+INITIALIZE_PASS(AArch64JeandleOptLoadGlobal, DEBUG_TYPE,
+                "Rewrite adrp+ldr @oop -> movz(G0)+movk(G1)+movk(G2)", false,
+                false)

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -242,6 +242,7 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeAArch64Target() {
   initializeAArch64ConditionOptimizerPass(*PR);
   initializeAArch64DeadRegisterDefinitionsPass(*PR);
   initializeAArch64ExpandPseudoPass(*PR);
+  initializeAArch64JeandleOptLoadGlobalPass(*PR);
   initializeAArch64LoadStoreOptPass(*PR);
   initializeAArch64MIPeepholeOptPass(*PR);
   initializeAArch64SIMDInstrOptPass(*PR);
@@ -895,6 +896,9 @@ void AArch64PassConfig::addPreEmitPass2() {
   // SVE bundles move prefixes with destructive operations. BLR_RVMARKER pseudo
   // instructions are lowered to bundles as well.
   addPass(createUnpackMachineBundles(nullptr));
+
+  // Final machine instruction optimization before AsmPrinter emission.
+  addPass(createAArch64JeandleOptLoadGlobalPass());
 }
 
 bool AArch64PassConfig::addRegAssignAndRewriteOptimized() {

--- a/llvm/lib/Target/AArch64/CMakeLists.txt
+++ b/llvm/lib/Target/AArch64/CMakeLists.txt
@@ -64,6 +64,7 @@ add_llvm_target(AArch64CodeGen
   AArch64ISelLowering.cpp
   AArch64InstrInfo.cpp
   AArch64LoadStoreOptimizer.cpp
+  AArch64JeandleOptLoadGlobal.cpp
   AArch64LowerHomogeneousPrologEpilog.cpp
   AArch64MachineFunctionInfo.cpp
   AArch64MachineScheduler.cpp

--- a/llvm/lib/Target/X86/CMakeLists.txt
+++ b/llvm/lib/Target/X86/CMakeLists.txt
@@ -69,6 +69,7 @@ set(sources
   X86MachineFunctionInfo.cpp
   X86MacroFusion.cpp
   X86OptimizeLEAs.cpp
+  X86JeandleOptLoadGlobal.cpp
   X86PadShortFunction.cpp
   X86PartialReduction.cpp
   X86RegisterInfo.cpp

--- a/llvm/lib/Target/X86/X86.h
+++ b/llvm/lib/Target/X86/X86.h
@@ -70,6 +70,9 @@ FunctionPass *createX86FixupVectorConstants();
 /// recalculations.
 FunctionPass *createX86OptimizeLEAs();
 
+/// This pass optimizes loads of specially-marked global variables.
+FunctionPass *createX86JeandleOptLoadGlobalPass();
+
 /// Return a pass that transforms setcc + movzx pairs into xor + setcc.
 FunctionPass *createX86FixupSetCC();
 
@@ -198,6 +201,7 @@ void initializeX86LowerAMXIntrinsicsLegacyPassPass(PassRegistry &);
 void initializeX86LowerAMXTypeLegacyPassPass(PassRegistry &);
 void initializeX86LowerTileCopyPass(PassRegistry &);
 void initializeX86OptimizeLEAPassPass(PassRegistry &);
+void initializeX86JeandleOptLoadGlobalPass(PassRegistry &);
 void initializeX86PartialReductionPass(PassRegistry &);
 void initializeX86PreTileConfigPass(PassRegistry &);
 void initializeX86ReturnThunksPass(PassRegistry &);

--- a/llvm/lib/Target/X86/X86JeandleOptLoadGlobal.cpp
+++ b/llvm/lib/Target/X86/X86JeandleOptLoadGlobal.cpp
@@ -1,0 +1,95 @@
+//===- X86JeandleOptLoadGlobal.cpp - optimization of load global ----------===//
+//
+// Copyright (c) 2025, the Jeandle-LLVM Authors. All Rights Reserved.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the pass that optimizes loads of specially-marked
+// global variables. For any instruction of the form:
+//     movq GV(%rip), %dst
+// where GV has metadata "jeandle.oop.handle", replaces it with:
+//     movabsq $GV, %dst
+// Safe in Jeandle: JeandleVM rewrites such oop handles into real
+// object references (oops) and continuously maintains them at
+// runtime to guarantee correctness and garbage-collection safety.
+//
+//===----------------------------------------------------------------------===//
+
+#include "X86.h"
+#include "X86InstrInfo.h"
+#include "X86MachineFunctionInfo.h"
+#include "X86Subtarget.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/IR/GlobalVariable.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm/Support/Debug.h"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "x86-jeandle-opt-load-global"
+
+namespace {
+
+class X86JeandleOptLoadGlobal : public MachineFunctionPass {
+public:
+  static char ID;
+  X86JeandleOptLoadGlobal() : MachineFunctionPass(ID) {}
+
+  StringRef getPassName() const override {
+    return "X86 Jeandle Opt Load Global";
+  }
+
+  bool runOnMachineFunction(MachineFunction &MF) override {
+    if (MF.getFunction().isDeclaration())
+      return false;
+
+    const X86Subtarget &STI = MF.getSubtarget<X86Subtarget>();
+    const X86InstrInfo *TII = STI.getInstrInfo();
+    bool Changed = false;
+
+    for (MachineBasicBlock &MBB : MF) {
+      for (auto I = MBB.begin(), E = MBB.end(); I != E;) {
+        MachineInstr &MI = *I;
+        ++I; // Iterate safely: increment before possibly erasing current instr.
+
+        if (MI.getOpcode() != X86::MOV64rm)
+          continue;
+
+        const MachineOperand &DispOp = MI.getOperand(4);
+        if (!DispOp.isGlobal())
+          continue;
+
+        // Only optimize globals marked with custom metadata.
+        const GlobalVariable *GV = dyn_cast<GlobalVariable>(DispOp.getGlobal());
+        if (!GV || !GV->getMetadata("jeandle.oop.handle"))
+          continue;
+
+        Register DstReg = MI.getOperand(0).getReg();
+        BuildMI(MBB, MI, MI.getDebugLoc(), TII->get(X86::MOV64ri))
+            .addReg(DstReg)
+            .addGlobalAddress(GV, DispOp.getOffset(), DispOp.getTargetFlags());
+
+        MI.eraseFromParent();
+        Changed = true;
+      }
+    }
+    return Changed;
+  }
+};
+
+} // end anonymous namespace
+
+char X86JeandleOptLoadGlobal::ID = 0;
+
+FunctionPass *llvm::createX86JeandleOptLoadGlobalPass() {
+  return new X86JeandleOptLoadGlobal();
+}
+
+INITIALIZE_PASS(X86JeandleOptLoadGlobal, DEBUG_TYPE,
+                "Rewrite mov @oop(%rip), %reg -> movabs $@oop_addr, %reg",
+                false, false)

--- a/llvm/lib/Target/X86/X86TargetMachine.cpp
+++ b/llvm/lib/Target/X86/X86TargetMachine.cpp
@@ -77,6 +77,7 @@ extern "C" LLVM_C_ABI void LLVMInitializeX86Target() {
   initializeFixupBWInstPassPass(PR);
   initializeCompressEVEXPassPass(PR);
   initializeFixupLEAPassPass(PR);
+  initializeX86JeandleOptLoadGlobalPass(PR);
   initializeFPSPass(PR);
   initializeX86FixupSetCCPassPass(PR);
   initializeX86CallFrameOptimizationPass(PR);
@@ -666,6 +667,9 @@ void X86PassConfig::addPreEmitPass2() {
             (M->getFunction("objc_retainAutoreleasedReturnValue") ||
              M->getFunction("objc_unsafeClaimAutoreleasedReturnValue")));
   }));
+
+  // Final machine instruction optimization before AsmPrinter emission.
+  addPass(createX86JeandleOptLoadGlobalPass());
 }
 
 bool X86PassConfig::addPostFastRegAllocRewrite() {


### PR DESCRIPTION
[JeandleVM]Add target-specific passes to optimize global variable
loads on x86-64 and AArch64

Introduce two new machine passes:
- X86JeandleOptLoadGlobal for x86-64
- AArch64JeandleOptLoadGlobal for AArch64

These passes run after instruction selection and transform load
instructions from global variables into immediate-move instructions
that embed the values as a constant.

These transformations are **only valid under JeandleVM**, which
patches the immediate operands at runtime to the actual values of
the global variables.