### PR TITLE
fix: rewrite landingpad type to token in RS4GC

### DIFF
--- a/llvm/include/llvm/IR/Jeandle/GCStrategy.h
+++ b/llvm/include/llvm/IR/Jeandle/GCStrategy.h
@@ -11,9 +11,13 @@
 #ifndef JEANDLE_GCSTRATEGY_H
 #define JEANDLE_GCSTRATEGY_H
 
+#include "llvm/ADT/StringRef.h"
+
 namespace llvm::jeandle {
 
 constexpr const char *JeandleGC = "hotspotgc";
+
+static bool isJeandleGC(StringRef Name) { return Name == JeandleGC; }
 
 void linkAllJeandleGCs();
 

--- a/llvm/include/llvm/IR/Jeandle/GCStrategy.h
+++ b/llvm/include/llvm/IR/Jeandle/GCStrategy.h
@@ -17,7 +17,7 @@ namespace llvm::jeandle {
 
 constexpr const char *JeandleGC = "hotspotgc";
 
-static bool isJeandleGC(StringRef Name) { return Name == JeandleGC; }
+bool isJeandleGC(StringRef Name);
 
 void linkAllJeandleGCs();
 

--- a/llvm/lib/IR/Jeandle/GCStrategy.cpp
+++ b/llvm/lib/IR/Jeandle/GCStrategy.cpp
@@ -38,8 +38,9 @@ public:
 
 namespace llvm::jeandle {
 
-static llvm::GCRegistry::Add<HotspotGC> A(llvm::jeandle::JeandleGC,
-                                          "For Jeandle GC.");
+static llvm::GCRegistry::Add<HotspotGC> A(JeandleGC, "For Jeandle GC.");
+
+bool isJeandleGC(StringRef Name) { return Name == JeandleGC; }
 
 void linkAllJeandleGCs() {}
 

--- a/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
+++ b/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
@@ -1881,9 +1881,12 @@ makeStatepointExplicitImpl(CallBase *Call, /* to replace */
 
     // Attach exceptional gc relocates to the landingpad.
     Instruction *ExceptionalToken = UnwindBlock->getLandingPadInst();
-    if (ExceptionalToken->getType() != Type::getTokenTy(ExceptionalToken->getContext())) {
-      assert(ExceptionalToken->user_empty() && "Unsupported landingpad type when using statepoint!");
-      ExceptionalToken->mutateType(Type::getTokenTy(ExceptionalToken->getContext()));
+    if (ExceptionalToken->getType() !=
+        Type::getTokenTy(ExceptionalToken->getContext())) {
+      assert(ExceptionalToken->user_empty() &&
+             "Unsupported landingpad type when using statepoint!");
+      ExceptionalToken->mutateType(
+          Type::getTokenTy(ExceptionalToken->getContext()));
     }
 
     Result.UnwindToken = ExceptionalToken;

--- a/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
+++ b/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
@@ -1881,6 +1881,11 @@ makeStatepointExplicitImpl(CallBase *Call, /* to replace */
 
     // Attach exceptional gc relocates to the landingpad.
     Instruction *ExceptionalToken = UnwindBlock->getLandingPadInst();
+    if (ExceptionalToken->getType() != Type::getTokenTy(ExceptionalToken->getContext())) {
+      assert(ExceptionalToken->user_empty() && "Unsupported landingpad type when using statepoint!");
+      ExceptionalToken->mutateType(Type::getTokenTy(ExceptionalToken->getContext()));
+    }
+
     Result.UnwindToken = ExceptionalToken;
 
     CreateGCRelocates(LiveVariables, BasePtrs, ExceptionalToken, Builder, GC);

--- a/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
+++ b/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
@@ -46,6 +46,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/Jeandle/GCStrategy.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/MDBuilder.h"
 #include "llvm/IR/Metadata.h"
@@ -1881,10 +1882,11 @@ makeStatepointExplicitImpl(CallBase *Call, /* to replace */
 
     // Attach exceptional gc relocates to the landingpad.
     Instruction *ExceptionalToken = UnwindBlock->getLandingPadInst();
-    if (ExceptionalToken->getType() !=
-        Type::getTokenTy(ExceptionalToken->getContext())) {
+    if (jeandle::isJeandleGC(Call->getCaller()->getGC()) &&
+        ExceptionalToken->getType() !=
+            Type::getTokenTy(ExceptionalToken->getContext())) {
       assert(ExceptionalToken->user_empty() &&
-             "Unsupported landingpad type when using statepoint!");
+             "Unsupported landingpad type for Jeandle when using statepoint!");
       ExceptionalToken->mutateType(
           Type::getTokenTy(ExceptionalToken->getContext()));
     }

--- a/llvm/test/Jeandle/landingpad-type.ll
+++ b/llvm/test/Jeandle/landingpad-type.ll
@@ -1,0 +1,21 @@
+; RUN: opt -S --passes=rewrite-statepoints-for-gc %s 2>&1 | FileCheck %s
+
+; CHECK: landingpad token
+
+@jeandle.personality = global ptr null
+
+define hotspotcc void @test(i32 %0) gc "hotspotgc" personality ptr @jeandle.personality {
+entry:
+  invoke hotspotcc void @callee()
+          to label %bci_21_normal_dest unwind label %bci_21_unwind_dest
+
+bci_21_unwind_dest:                               ; preds = %entry
+  %14 = landingpad i64
+          cleanup
+  ret void
+
+bci_21_normal_dest:                               ; preds = %entry
+  ret void
+}
+
+declare hotspotcc void @callee() gc "hotspotgc"


### PR DESCRIPTION
## Related issue(s):

https://github.com/jeandle/jeandle-jdk/issues/174

## What this PR does / why we need it:

Statepoints require landingpad type to be token, but if we define landingpad type as token in frontend, some optimization passes will fail. So we rewrite landingpad type in RewriteStatepoints4GC.