### PR TITLE
feat: Insert G1GC barriers

### DIFF
--- a/llvm/lib/Transforms/Jeandle/InsertGCBarriers.cpp
+++ b/llvm/lib/Transforms/Jeandle/InsertGCBarriers.cpp
@@ -67,9 +67,11 @@ PreservedAnalyses InsertGCBarriers::run(Function &F,
     return PreservedAnalyses::all();
   }
 
-  Function *CardTableBarrierFunc = M->getFunction("jeandle.card_table_barrier");
-  assert(CardTableBarrierFunc != nullptr &&
-         "jeandle.card_table_barrier must exist");
+  Function *PreBarrierFunc = M->getFunction("jeandle.pre_barrier");
+  assert(PreBarrierFunc != nullptr && "jeandle.pre_barrier must exist");
+
+  Function *PostBarrierFunc = M->getFunction("jeandle.post_barrier");
+  assert(PostBarrierFunc != nullptr && "jeandle.post_barrier must exist");
 
   LLVM_DEBUG(dbgs() << "Inserting GC barriers in " << F.getName() << "\n");
   SmallVector<StoreInst *> JavaHeapStores;
@@ -80,15 +82,25 @@ PreservedAnalyses InsertGCBarriers::run(Function &F,
   }
 
   for (auto SI : JavaHeapStores) {
-    IRBuilder<> Builder(SI->getNextNode());
-
     Value *DerivedPointer = SI->getPointerOperand();
+    Value *StoredValue = SI->getValueOperand();
     Type *PointerTy = DerivedPointer->getType();
-    Value *BasePointer = Builder.CreateIntrinsic(
-        Intrinsic::experimental_gc_get_pointer_base, {PointerTy, PointerTy},
-        {DerivedPointer}, {} /* FMFSource */, "base.pointer");
-    CallInst *call = Builder.CreateCall(CardTableBarrierFunc, BasePointer);
-    call->setCallingConv(CallingConv::Hotspot_JIT);
+
+    // Insert pre-barrier before the store.
+    IRBuilder<> PreBuilder(SI);
+    CallInst *PreCall = PreBuilder.CreateCall(PreBarrierFunc, DerivedPointer);
+    PreCall->setCallingConv(CallingConv::Hotspot_JIT);
+
+    // Insert post-barrier after the store.
+    if (!isa<ConstantPointerNull>(StoredValue)) {
+      IRBuilder<> PostBuilder(SI->getNextNode());
+      Value *BasePointer = PostBuilder.CreateIntrinsic(
+          Intrinsic::experimental_gc_get_pointer_base, {PointerTy, PointerTy},
+          {DerivedPointer}, {} /* FMFSource */, "base.pointer");
+      CallInst *PostCall =
+          PostBuilder.CreateCall(PostBarrierFunc, {BasePointer, StoredValue});
+      PostCall->setCallingConv(CallingConv::Hotspot_JIT);
+    }
     Changed = true;
   }
 

--- a/llvm/test/Jeandle/g1-barrier.ll
+++ b/llvm/test/Jeandle/g1-barrier.ll
@@ -49,4 +49,4 @@ entry:
 
 attributes #0 = { noinline "lower-phase"="1" }
 
-!java_method_compilation = !{}
+!java-method-compilation = !{}

--- a/llvm/test/Jeandle/g1-barrier.ll
+++ b/llvm/test/Jeandle/g1-barrier.ll
@@ -1,14 +1,25 @@
 ; RUN: opt -S -passes="java-operation-lower<phase=0>,insert-gc-barriers,java-operation-lower<phase=1>" %s 2>&1 | FileCheck %s
 
 ; CHECK: %derived.pointer = getelementptr inbounds i8, ptr addrspace(1) %dst, i64 24
+; CHECK-NEXT: %0 = load atomic ptr addrspace(1), ptr addrspace(1) %derived.pointer unordered, align 8
+; CHECK-NEXT: store ptr addrspace(1) %0, ptr @satb_log
 ; CHECK-NEXT: store atomic ptr addrspace(1) %src, ptr addrspace(1) %derived.pointer unordered, align 8
 ; CHECK-NEXT: %base.pointer = call ptr addrspace(1) @llvm.experimental.gc.get.pointer.base.p1.p1(ptr addrspace(1) %derived.pointer)
-; CHECK-NEXT: %0 = ptrtoint ptr addrspace(1) %base.pointer to i64
-; CHECK-NEXT: %1 = lshr i64 %0, 9
-; CHECK-NEXT: %2 = getelementptr inbounds i8, ptr inttoptr (i64 139709660639232 to ptr), i64 %1
-; CHECK-NEXT: store atomic i8 0, ptr %2 unordered, align 1
+; CHECK-NEXT: %1 = ptrtoint ptr addrspace(1) %base.pointer to i64
+; CHECK-NEXT: %2 = lshr i64 %1, 9
+; CHECK-NEXT: %3 = getelementptr inbounds i8, ptr inttoptr (i64 139709660639232 to ptr), i64 %2
+; CHECK-NEXT: store atomic i8 0, ptr %3 unordered, align 1
 
-define private hotspotcc void @jeandle.card_table_barrier(ptr addrspace(1) %addr) #0 {
+@satb_log = private global ptr addrspace(1) null
+
+define private hotspotcc void @jeandle.g1_pre_barrier(ptr addrspace(1) %addr) #0 {
+entry:
+  %0 = load atomic ptr addrspace(1), ptr addrspace(1) %addr unordered, align 8
+  store ptr addrspace(1) %0, ptr @satb_log
+  ret void
+}
+
+define private hotspotcc void @jeandle.g1_post_barrier(ptr addrspace(1) %addr, ptr addrspace(1) %val) #0 {
 entry:
   %0 = ptrtoint ptr addrspace(1) %addr to i64
   %1 = lshr i64 %0, 9
@@ -19,23 +30,23 @@ entry:
 
 define private hotspotcc void @jeandle.pre_barrier(ptr addrspace(1) %addr) #0 {
 entry:
+  call void @jeandle.g1_pre_barrier(ptr addrspace(1) %addr)
   ret void
 }
 
 define private hotspotcc void @jeandle.post_barrier(ptr addrspace(1) %addr, ptr addrspace(1) captures(none) %oop) #0 {
 entry:
-  call void @jeandle.card_table_barrier(ptr addrspace(1) %addr)
+  call void @jeandle.g1_post_barrier(ptr addrspace(1) %addr, ptr addrspace(1) %oop)
   ret void
 }
 
-define hotspotcc void @test_card_table_barrier(ptr addrspace(1) %dst, ptr addrspace(1) %src) gc "hotspotgc" {
-entry:                                        ; preds = %entry
+define hotspotcc void @test_g1_barrier(ptr addrspace(1) %dst, ptr addrspace(1) %src) gc "hotspotgc" {
+entry:
   %derived.pointer = getelementptr inbounds i8, ptr addrspace(1) %dst, i64 24
   store atomic ptr addrspace(1) %src, ptr addrspace(1) %derived.pointer unordered, align 8
   ret void
-
 }
 
 attributes #0 = { noinline "lower-phase"="1" }
 
-!java-method-compilation = !{}
+!java_method_compilation = !{}

--- a/llvm/test/Jeandle/lately-use-cross-default-opt.ll
+++ b/llvm/test/Jeandle/lately-use-cross-default-opt.ll
@@ -1,16 +1,18 @@
-; RUN: opt -S --passes=-S -passes="java-operation-lower<phase=0>,default<O3>,insert-gc-barriers" %s 2>&1 | FileCheck -check-prefix=CHECK-USE %s
-; RUN: opt -S --passes=-S -passes="java-operation-lower<phase=0>,default<O3>,insert-gc-barriers,java-operation-lower<phase=1>" %s 2>&1 | FileCheck -check-prefix=CHECK-ERASE %s
+; RUN: opt -S -passes="java-operation-lower<phase=0>,default<O3>,insert-gc-barriers" %s 2>&1 | FileCheck -check-prefix=CHECK-USE %s
+; RUN: opt -S -passes="java-operation-lower<phase=0>,default<O3>,insert-gc-barriers,java-operation-lower<phase=1>" %s 2>&1 | FileCheck -check-prefix=CHECK-ERASE %s
 
 ; CHECK-USE: @llvm.used = appending global
-; CHECK-USE: define hotspotcc void @test_card_table_barrier
+; CHECK-USE: define hotspotcc void @test_gc_write_barrier
 ; CHECK-USE: store atomic ptr addrspace(1) %src, ptr addrspace(1) %derived.pointer
 ; CHECK-USE-NEXT: %base.pointer = call ptr addrspace(1) @llvm.experimental.gc.get.pointer.base.p1.p1(ptr addrspace(1) %derived.pointer)
-; CHECK-USE-NEXT: call hotspotcc void @jeandle.card_table_barrier(ptr addrspace(1) %base.pointer)
+; CHECK-USE-NEXT: call hotspotcc void @jeandle.post_barrier(ptr addrspace(1) %base.pointer, ptr addrspace(1) %src)
 
 ; CHECK-ERASE-NOT: @llvm.used = appending global
 ; CHECK-ERASE-NOT: @jeandle.card_table_barrier
+; CHECK-ERASE-NOT: @jeandle.pre_barrier
+; CHECK-ERASE-NOT: @jeandle.post_barrier
 
-@llvm.used = appending global [1 x ptr] [ptr @jeandle.card_table_barrier], section "llvm.metadata"
+@llvm.used = appending global [3 x ptr] [ptr @jeandle.card_table_barrier, ptr @jeandle.pre_barrier, ptr @jeandle.post_barrier], section "llvm.metadata"
 
 define private hotspotcc void @jeandle.card_table_barrier(ptr addrspace(1) %addr) #0 {
 entry:
@@ -21,7 +23,18 @@ entry:
   ret void
 }
 
-define hotspotcc void @test_card_table_barrier(ptr addrspace(1) %dst, ptr addrspace(1) %src) gc "hotspotgc" {
+define private hotspotcc void @jeandle.pre_barrier(ptr addrspace(1) %addr) #0 {
+entry:
+  ret void
+}
+
+define private hotspotcc void @jeandle.post_barrier(ptr addrspace(1) %addr, ptr addrspace(1) captures(none) %oop) #0 {
+entry:
+  call void @jeandle.card_table_barrier(ptr addrspace(1) %addr)
+  ret void
+}
+
+define hotspotcc void @test_gc_write_barrier(ptr addrspace(1) %dst, ptr addrspace(1) %src) gc "hotspotgc" {
 entry:                                        ; preds = %entry
   %derived.pointer = getelementptr inbounds i8, ptr addrspace(1) %dst, i64 24
   store atomic ptr addrspace(1) %src, ptr addrspace(1) %derived.pointer unordered, align 8


### PR DESCRIPTION
## Related issue(s):

issue #48 

## What this PR does / why we need it:
This PR implements G1GC barrier insertion in the LLVM JIT compiler. It cooprates with https://github.com/jeandle/jeandle-jdk/pull/367

- The pass inserts calls to pre_barrier and post_barrier wrapper functions, which internally select the appropriate barrier based on GC type.
- Pre-barrier receives the derived pointer for correct old value loading.
- Post-barrier receives both the base pointer and the stored value for g1_post_barrier cross-region check.
