### PR TITLE
fix: upgrade clang-format version to resolve unrecognized LineEnding

### DIFF
--- a/.github/workflows/jeandle-llvm-test.yml
+++ b/.github/workflows/jeandle-llvm-test.yml
@@ -52,10 +52,14 @@ jobs:
           fetch-depth: 1
       - name: clang-format
         run : |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main"
+          sudo apt install -y clang-format-16
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-16 180
+
           git remote add jeandle-main https://github.com/jeandle/jeandle-llvm.git
           git fetch --depth=1 jeandle-main
-          sudo apt-get install -y clang-format
-          git clang-format jeandle-main/main
+          git clang-format-16 jeandle-main/main
           if [ -n "$(git status --porcelain)" ]; then
             echo "Format check failed!"
             exit 1


### PR DESCRIPTION
## Related issue(s):
#51 

## What this PR does / why we need it:
upgrade clang-format version to resolve unrecognized LineEnding