### PR TITLE
enhance: refactor the VM callback log to map based implementation

### DIFF
--- a/llvm/include/llvm/IR/Jeandle/VMCallback.h
+++ b/llvm/include/llvm/IR/Jeandle/VMCallback.h
@@ -1,6 +1,6 @@
 //===- VMCallback.h - VM Callback Interface -------------------------------===//
 //
-// Copyright (c) 2025, the Jeandle-LLVM Authors. All Rights Reserved.
+// Copyright (c) 2026, the Jeandle-LLVM Authors. All Rights Reserved.
 //
 // Part of the Jeandle-LLVM project, under the Apache License v2.0 with LLVM
 // Exceptions. See https://llvm.org/LICENSE.txt for license information.
@@ -48,21 +48,60 @@ enum class VMCallbackValueType : uint8_t {
 //   NumArgs  — number of arguments
 //
 // -----------------------------------------------------------------------------
-// CRITICAL: Sequential Consistency Requirement
+// Map-Based Replay and Purity Assumption
 //
-// The VMCallback Replay mechanism relies on a strict total ordering of callback
-// invocations. For a replay to be successful, the sequence of VM calls during
-// compilation must be identical to the sequence recorded in the log.
+// The VMCallback replay mechanism uses a map from (CallbackKind, Args) to
+// Result. Replay is order-independent: a callback during replay finds its
+// result by key lookup, not by sequential cursor advancement.
 //
-// Developers must ensure that any logic triggering VM callbacks follows a
-// deterministic execution path. Avoid issuing callbacks while iterating over
-// unordered containers (e.g., llvm::DenseMap or std::unordered_map).
+// All VM callbacks are assumed to be PURE FUNCTIONS: the same arguments
+// always produce the same result within a single compilation. If the same
+// (Kind, Args) is called with a different Result during recording, a fatal
+// error is reported (purity violation).
 //
-// Correct Example:
-//   for (Instruction &I : instructions(F)) { triggerCallback(I); }
+// DIVERGENCE RISK: While the map-based model eliminates ordering
+// requirements, callbacks must NOT be invoked in non-deterministic control
+// flow where the SET of callbacks invoked differs between record and replay.
+// This causes missing-key errors during replay.
 //
-// Incorrect Example:
-//   for (auto &Entry : UnorderedMap) { triggerCallback(Entry.second); }
+// The key question is: when is iteration order non-deterministic?
+//
+//   - SmallDenseSet<uintptr_t>: SAFE. LLVM's DenseMapInfo<uintptr_t> uses
+//     a pure deterministic hash (densemap::detail::mix) with no randomization
+//     or ASLR dependency. Iteration order is fully determined by the set of
+//     elements and their insertion/deletion history, which are the same
+//     between record and replay given the same IR and callback results.
+//
+//   - DenseMap<T*> / SmallDenseSet<T*> where T is a pointer type: UNSAFE.
+//     DenseMapInfo<T*> hashes the pointer address, which depends on ASLR
+//     and memory layout. Iteration order can differ between the JVM process
+//     (recording) and the opt process (replay).
+//
+//   - Any container with per-run randomization (e.g., LLVM's ReverseIterate
+//     mode with LLVM_ENABLE_REVERSE_ITERATION=1): UNSAFE.
+//
+// Patterns to AVOID:
+//   - Early exit (break/return) from iteration over a container with
+//     non-deterministic iteration order (e.g., DenseMap<T*>) where the
+//     exit condition depends on a callback result. Different iteration
+//     orders may cause different callbacks to be invoked before the exit,
+//     changing the recorded set.
+//
+//     BAD:  for (auto &Entry : DenseMap<SomeClass*, ...>) {
+//             if (IsSubtype(Entry.key, K)) return true;
+//           }
+//
+// Patterns that are SAFE:
+//   - Iterating SmallDenseSet<uintptr_t> with early exits (the current
+//     usage in isExcludedBy, addExcludedKlass, etc.). The hash function
+//     for uintptr_t is deterministic, so iteration order is reproducible.
+//   - Exhaustive iteration over any container (no early exit), where every
+//     callback in the set is always invoked regardless of iteration order.
+//     The map handles the ordering difference transparently.
+//   - Iterating ordered containers (arrays, sorted vectors, instruction
+//     lists) where iteration order is deterministic.
+//   - Any callback whose arguments are derived from deterministic inputs
+//     (instruction order, metadata, constants).
 // -----------------------------------------------------------------------------
 //
 // To add a new callback, add one row below, then implement the JDK-side

--- a/llvm/include/llvm/IR/Jeandle/VMCallbackLog.h
+++ b/llvm/include/llvm/IR/Jeandle/VMCallbackLog.h
@@ -1,6 +1,6 @@
 //===- VMCallbackLog.h - VM Callback Recording & Replay -------------------===//
 //
-// Copyright (c) 2025, the Jeandle-LLVM Authors. All Rights Reserved.
+// Copyright (c) 2026, the Jeandle-LLVM Authors. All Rights Reserved.
 //
 // Part of the Jeandle-LLVM project, under the Apache License v2.0 with LLVM
 // Exceptions. See https://llvm.org/LICENSE.txt for license information.
@@ -14,18 +14,24 @@
 //
 // Replay mode (--jeandle-vm-callback-log=<file>):
 //   Loads a callback log file and registers replay callbacks that answer
-//   queries from the recorded data. Entries are consumed sequentially.
+//   queries from the recorded data. Lookups are by (CallbackKind, Args) key,
+//   so replay is order-independent and deduplicated.
 //
 // Record mode (JVM-side):
 //   enableVMCallbackRecording() installs recording trampolines over the
 //   real VM callbacks. Each compilation creates a VMCallbackLogRecorder
 //   (RAII) to scope the recording, and calls dump() to write the log.
+//   Duplicate (Kind, Args) -> Result mappings are deduplicated; a
+//   conflicting result for the same (Kind, Args) triggers a fatal error
+//   (purity violation).
 //
 //===----------------------------------------------------------------------===//
 
 #ifndef JEANDLE_VM_CALLBACK_LOG_H
 #define JEANDLE_VM_CALLBACK_LOG_H
 
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/Jeandle/VMCallback.h"
 #include "llvm/Support/Error.h"
@@ -33,7 +39,6 @@
 
 #include <cstdint>
 #include <initializer_list>
-#include <vector>
 
 namespace llvm::jeandle {
 
@@ -71,17 +76,37 @@ enum CallbackKind : unsigned { ALL_JEANDLE_VM_CALLBACKS(DEF_CALLBACK_KIND) };
 #undef DEF_CALLBACK_KIND
 
 // =============================================================================
-// Log entry
+// Callback key for map-based lookup
 // =============================================================================
 
-/// A single recorded VM callback invocation.
-/// Args and Result are stored as int64_t to uniformly handle all types
-/// (uintptr_t, int, bool). Use the CallbackKind and CallbackInfo to
-/// interpret the types correctly during serialization and parsing.
-struct LogEntry {
+/// Key for deduplicated map-based recording and replay of VM callbacks.
+/// Each unique (Kind, Args) pair maps to exactly one Result, since all VM
+/// callbacks are pure functions.
+struct CallbackKey {
   unsigned Kind; // CallbackKind enum value
   SmallVector<int64_t, 4> Args;
-  int64_t Result;
+
+  bool operator==(const CallbackKey &Other) const {
+    return Kind == Other.Kind && Args == Other.Args;
+  }
+};
+
+/// DenseMapInfo for CallbackKey, using sentinel Kind values that cannot
+/// collide with valid CallbackKind enum values.
+struct CallbackKeyDenseMapInfo {
+  static inline CallbackKey getEmptyKey() {
+    return {DenseMapInfo<unsigned>::getEmptyKey(), {}};
+  }
+  static inline CallbackKey getTombstoneKey() {
+    return {DenseMapInfo<unsigned>::getTombstoneKey(), {}};
+  }
+  static unsigned getHashValue(const CallbackKey &Key) {
+    return hash_combine(Key.Kind,
+                        hash_combine_range(Key.Args.begin(), Key.Args.end()));
+  }
+  static bool isEqual(const CallbackKey &LHS, const CallbackKey &RHS) {
+    return LHS == RHS;
+  }
 };
 
 // =============================================================================
@@ -102,18 +127,20 @@ public:
   VMCallbackLogRecorder &operator=(const VMCallbackLogRecorder &) = delete;
 
   /// Write the recorded callback log to a file.
-  /// Each invocation appears as a separate line in call order.
+  /// Entries are deduplicated and sorted by (Kind, Args) for determinism.
   /// Returns Error::success() on success, or an error on failure.
   Error dump(StringRef FilePath);
 
   /// Get the active recorder for the current thread (used by trampolines).
   static VMCallbackLogRecorder *getActiveRecorder() { return ActiveRecorder; }
 
-  /// Append a log entry (used by recording trampolines).
-  void appendEntry(LogEntry Entry) { Entries.push_back(std::move(Entry)); }
+  /// Record a callback invocation result. If the (Kind, Args) key already
+  /// exists with a different Result, report a fatal error (purity violation).
+  /// If the key already exists with the same Result, this is a no-op (dedup).
+  void recordIfNew(unsigned Kind, ArrayRef<int64_t> Args, int64_t Result);
 
 private:
-  std::vector<LogEntry> Entries;
+  DenseMap<CallbackKey, int64_t, CallbackKeyDenseMapInfo> Entries;
   static thread_local VMCallbackLogRecorder *ActiveRecorder;
 };
 
@@ -130,12 +157,6 @@ template <> inline int64_t encodeVMCallbackValue<int>(int V) {
 }
 template <> inline int64_t encodeVMCallbackValue<bool>(bool V) {
   return V ? 1 : 0;
-}
-
-/// Build a LogEntry from a callback kind, result, and variadic arguments.
-template <typename... Ts>
-inline LogEntry makeLogEntry(unsigned Kind, int64_t Result, Ts... Args) {
-  return {Kind, {encodeVMCallbackValue(Args)...}, Result};
 }
 
 template <typename T> inline T decodeVMCallbackValue(int64_t V);
@@ -160,7 +181,9 @@ inline SmallVector<int64_t, 4> encodeArgs(Ts... Args) {
 // =============================================================================
 
 /// Parse a VM callback log file and register replay callbacks.
-/// Entries are consumed sequentially during replay.
+/// Entries are looked up by (CallbackKind, Args) key during replay.
+/// Duplicate entries with the same key and result are silently accepted;
+/// conflicting duplicates (same key, different result) produce an error.
 /// Returns Error::success() on success, or an error on failure.
 Error loadAndRegisterVMCallbackLog(StringRef FilePath);
 

--- a/llvm/lib/IR/Jeandle/VMCallbackLog.cpp
+++ b/llvm/lib/IR/Jeandle/VMCallbackLog.cpp
@@ -1,6 +1,6 @@
 //===- VMCallbackLog.cpp - VM Callback Recording & Replay -----------------===//
 //
-// Copyright (c) 2025, the Jeandle-LLVM Authors. All Rights Reserved.
+// Copyright (c) 2026, the Jeandle-LLVM Authors. All Rights Reserved.
 //
 // Part of the Jeandle-LLVM project, under the Apache License v2.0 with LLVM
 // Exceptions. See https://llvm.org/LICENSE.txt for license information.
@@ -17,6 +17,8 @@
 
 #include <cstdlib>
 #include <memory>
+#include <tuple>
+#include <utility>
 
 using namespace llvm;
 using namespace llvm::jeandle;
@@ -62,6 +64,25 @@ VMCallbackLogRecorder::VMCallbackLogRecorder() {
 
 VMCallbackLogRecorder::~VMCallbackLogRecorder() { ActiveRecorder = nullptr; }
 
+void VMCallbackLogRecorder::recordIfNew(unsigned Kind, ArrayRef<int64_t> Args,
+                                        int64_t Result) {
+  CallbackKey Key{Kind, SmallVector<int64_t, 4>(Args.begin(), Args.end())};
+  auto [It, Inserted] = Entries.try_emplace(Key, Result);
+  if (!Inserted && It->second != Result) {
+    const auto &Info = getCallbackTable()[Kind];
+    std::string ArgStr;
+    raw_string_ostream OS(ArgStr);
+    for (size_t I = 0; I < Args.size(); ++I) {
+      if (I > 0)
+        OS << ", ";
+      OS << Args[I];
+    }
+    report_fatal_error("VMCallbackLog purity violation: " + Twine(Info.Name) +
+                       "(" + ArgStr + ") returned " + Twine(Result) +
+                       ", previously " + Twine(It->second));
+  }
+}
+
 Error VMCallbackLogRecorder::dump(StringRef FilePath) {
   std::error_code EC;
   raw_fd_ostream OS(FilePath, EC, sys::fs::OF_Text);
@@ -69,33 +90,43 @@ Error VMCallbackLogRecorder::dump(StringRef FilePath) {
     return createStringError(EC, "cannot open file '%s': %s",
                              FilePath.str().c_str(), EC.message().c_str());
 
-  for (const auto &Entry : Entries) {
-    const auto &Info = getCallbackTable()[Entry.Kind];
+  // Collect entries and sort by (Kind, Args) for deterministic output.
+  SmallVector<std::pair<CallbackKey, int64_t>, 16> SortedEntries;
+  for (const auto &KV : Entries)
+    SortedEntries.emplace_back(KV.getFirst(), KV.getSecond());
+  llvm::sort(SortedEntries,
+             [](const auto &A, const auto &B) {
+               return std::tie(A.first.Kind, A.first.Args) <
+                      std::tie(B.first.Kind, B.first.Args);
+             });
+
+  for (const auto &[Key, Result] : SortedEntries) {
+    const auto &Info = getCallbackTable()[Key.Kind];
     OS << Info.Name;
     for (unsigned I = 0; I < Info.ArgTypes.size(); ++I) {
       OS << " ";
       switch (Info.ArgTypes[I]) {
       case VMCallbackValueType::Uintptr:
-        OS << static_cast<uintptr_t>(Entry.Args[I]);
+        OS << static_cast<uintptr_t>(Key.Args[I]);
         break;
       case VMCallbackValueType::Int:
-        OS << static_cast<int>(Entry.Args[I]);
+        OS << static_cast<int>(Key.Args[I]);
         break;
       case VMCallbackValueType::Bool:
-        OS << (Entry.Args[I] ? "true" : "false");
+        OS << (Key.Args[I] ? "true" : "false");
         break;
       }
     }
     OS << " = ";
     switch (Info.ResType) {
     case VMCallbackValueType::Bool:
-      OS << (Entry.Result ? "true" : "false");
+      OS << (Result ? "true" : "false");
       break;
     case VMCallbackValueType::Uintptr:
-      OS << static_cast<uintptr_t>(Entry.Result);
+      OS << static_cast<uintptr_t>(Result);
       break;
     case VMCallbackValueType::Int:
-      OS << static_cast<int>(Entry.Result);
+      OS << static_cast<int>(Result);
       break;
     }
     OS << "\n";
@@ -121,8 +152,8 @@ static VMCallbacks RealCallbacks;
   static RetType record##Name Params {                                         \
     RetType Result = RealCallbacks.Name(JEANDLE_STRIP_PARENS Args);            \
     if (auto *R = VMCallbackLogRecorder::getActiveRecorder())                  \
-      R->appendEntry(makeLogEntry(CK_##Name, static_cast<int64_t>(Result),     \
-                                  JEANDLE_STRIP_PARENS Args));                 \
+      R->recordIfNew(CK_##Name, encodeArgs(JEANDLE_STRIP_PARENS Args),         \
+                     static_cast<int64_t>(Result));                            \
     return Result;                                                             \
   }
 
@@ -163,64 +194,43 @@ void jeandle::enableVMCallbackRecording() {
 namespace {
 
 struct ReplayData {
-  std::vector<LogEntry> Entries;
-  size_t Cursor = 0;
+  DenseMap<CallbackKey, int64_t, CallbackKeyDenseMapInfo> Entries;
 };
 
 static std::unique_ptr<ReplayData> LogData;
 
-/// Consume the next log entry. Terminates if the log is not initialized,
-/// exhausted, or the entry does not match the expected callback kind and args.
-/// On success, advances the cursor.
-static void consumeEntry(unsigned ExpectedKind, ArrayRef<int64_t> ExpectedArgs,
-                         const char *CallbackName) {
+/// Look up a callback result by (Kind, Args). Terminates if the log is
+/// not initialized or the key is not found.
+static int64_t lookupResult(unsigned Kind, ArrayRef<int64_t> Args,
+                            const char *CallbackName) {
   if (!LogData) {
     report_fatal_error("VMCallbackLog replay not initialized at " +
                        Twine(CallbackName));
   }
-  if (LogData->Cursor >= LogData->Entries.size()) {
-    std::string Args;
-    raw_string_ostream OS(Args);
-    for (size_t I = 0; I < ExpectedArgs.size(); ++I) {
+  CallbackKey Key{Kind, SmallVector<int64_t, 4>(Args.begin(), Args.end())};
+  auto It = LogData->Entries.find(Key);
+  if (It == LogData->Entries.end()) {
+    std::string ArgStr;
+    raw_string_ostream OS(ArgStr);
+    for (size_t I = 0; I < Args.size(); ++I) {
       if (I > 0)
         OS << ", ";
-      OS << ExpectedArgs[I];
+      OS << Args[I];
     }
-    report_fatal_error("VMCallbackLog exhausted at " + Twine(CallbackName) +
-                       "(" + Args + ")");
+    report_fatal_error("VMCallbackLog missing entry for " +
+                       Twine(CallbackName) + "(" + ArgStr + ")");
   }
-  const auto &Entry = LogData->Entries[LogData->Cursor];
-  if (Entry.Kind != ExpectedKind ||
-      ArrayRef<int64_t>(Entry.Args) != ExpectedArgs) {
-    std::string Expected, Actual;
-    raw_string_ostream ExpOS(Expected);
-    raw_string_ostream ActOS(Actual);
-    for (size_t I = 0; I < ExpectedArgs.size(); ++I) {
-      if (I > 0)
-        ExpOS << ", ";
-      ExpOS << ExpectedArgs[I];
-    }
-    ActOS << getCallbackTable()[Entry.Kind].Name << "(";
-    for (size_t I = 0; I < Entry.Args.size(); ++I) {
-      if (I > 0)
-        ActOS << ", ";
-      ActOS << Entry.Args[I];
-    }
-    ActOS << ")";
-    report_fatal_error("VMCallbackLog mismatch at " + Twine(CallbackName) +
-                       "(" + Expected + "): expected entry [" +
-                       Twine(LogData->Cursor) + "] is " + Actual);
-  }
-  LogData->Cursor++;
+  return It->second;
 }
 
 // REPLAY_CALLBACK(Name, RetType, (param-decls), (arg-names))
 // Same parenthesized-params pattern as RECORD_CALLBACK.
 #define REPLAY_CALLBACK(Name, RetType, Params, Args)                           \
   static RetType replay##Name Params {                                         \
-    consumeEntry(CK_##Name, encodeArgs(JEANDLE_STRIP_PARENS Args), #Name);     \
-    return decodeVMCallbackValue<RetType>(                                     \
-        LogData->Entries[LogData->Cursor - 1].Result);                         \
+    int64_t RawResult = lookupResult(CK_##Name,                                \
+                                     encodeArgs(JEANDLE_STRIP_PARENS Args),    \
+                                     #Name);                                   \
+    return decodeVMCallbackValue<RetType>(RawResult);                          \
   }
 
 #define DEF_REPLAY_CB(Name, RetType, ResType, Params, Args, ArgTypes, NumArgs) \
@@ -279,7 +289,9 @@ static std::optional<int64_t> parseValue(StringRef Token,
   return std::nullopt;
 }
 
-static Error parseLogBuffer(StringRef Buffer, std::vector<LogEntry> &Entries) {
+static Error
+parseLogBuffer(StringRef Buffer,
+               DenseMap<CallbackKey, int64_t, CallbackKeyDenseMapInfo> &Entries) {
   SmallVector<StringRef, 0> Lines;
   Buffer.split(Lines, '\n');
 
@@ -343,8 +355,15 @@ static Error parseLogBuffer(StringRef Buffer, std::vector<LogEntry> &Entries) {
       return createStringError("line %zu: invalid result for '%s': '%s'",
                                LineNum + 1, Info.Name, ResultStr.str().c_str());
 
-    Entries.push_back(
-        {Kind, SmallVector<int64_t, 4>(Args.begin(), Args.end()), *Result});
+    // Insert into map; error on conflicting duplicates.
+    CallbackKey Key{Kind, SmallVector<int64_t, 4>(Args.begin(), Args.end())};
+    auto [It, Inserted] = Entries.try_emplace(Key, *Result);
+    if (!Inserted && It->second != *Result) {
+      return createStringError(
+          "line %zu: conflicting result for '%s': previously %lld, now %lld",
+          LineNum + 1, Info.Name, static_cast<long long>(It->second),
+          static_cast<long long>(*Result));
+    }
   }
 
   return Error::success();
@@ -360,10 +379,12 @@ Error jeandle::loadAndRegisterVMCallbackLog(StringRef FilePath) {
     return createStringError(EC, "cannot open file '%s': %s",
                              FilePath.str().c_str(), EC.message().c_str());
 
-  LogData = std::make_unique<ReplayData>();
+  auto ParsedData = std::make_unique<ReplayData>();
   if (Error Err =
-          parseLogBuffer(BufferOrErr.get()->getBuffer(), LogData->Entries))
+          parseLogBuffer(BufferOrErr.get()->getBuffer(), ParsedData->Entries))
     return Err;
+
+  LogData = std::move(ParsedData);
 
   VMCallbacks ReplayCallbacks;
 #define DEF_REPLAY_WIRING(Name, RetType, ResType, Params, Args, ArgTypes,      \

--- a/llvm/lib/IR/Jeandle/VMCallbackLog.cpp
+++ b/llvm/lib/IR/Jeandle/VMCallbackLog.cpp
@@ -94,11 +94,10 @@ Error VMCallbackLogRecorder::dump(StringRef FilePath) {
   SmallVector<std::pair<CallbackKey, int64_t>, 16> SortedEntries;
   for (const auto &KV : Entries)
     SortedEntries.emplace_back(KV.getFirst(), KV.getSecond());
-  llvm::sort(SortedEntries,
-             [](const auto &A, const auto &B) {
-               return std::tie(A.first.Kind, A.first.Args) <
-                      std::tie(B.first.Kind, B.first.Args);
-             });
+  llvm::sort(SortedEntries, [](const auto &A, const auto &B) {
+    return std::tie(A.first.Kind, A.first.Args) <
+           std::tie(B.first.Kind, B.first.Args);
+  });
 
   for (const auto &[Key, Result] : SortedEntries) {
     const auto &Info = getCallbackTable()[Key.Kind];
@@ -227,9 +226,8 @@ static int64_t lookupResult(unsigned Kind, ArrayRef<int64_t> Args,
 // Same parenthesized-params pattern as RECORD_CALLBACK.
 #define REPLAY_CALLBACK(Name, RetType, Params, Args)                           \
   static RetType replay##Name Params {                                         \
-    int64_t RawResult = lookupResult(CK_##Name,                                \
-                                     encodeArgs(JEANDLE_STRIP_PARENS Args),    \
-                                     #Name);                                   \
+    int64_t RawResult =                                                        \
+        lookupResult(CK_##Name, encodeArgs(JEANDLE_STRIP_PARENS Args), #Name); \
     return decodeVMCallbackValue<RetType>(RawResult);                          \
   }
 
@@ -289,9 +287,9 @@ static std::optional<int64_t> parseValue(StringRef Token,
   return std::nullopt;
 }
 
-static Error
-parseLogBuffer(StringRef Buffer,
-               DenseMap<CallbackKey, int64_t, CallbackKeyDenseMapInfo> &Entries) {
+static Error parseLogBuffer(
+    StringRef Buffer,
+    DenseMap<CallbackKey, int64_t, CallbackKeyDenseMapInfo> &Entries) {
   SmallVector<StringRef, 0> Lines;
   Buffer.split(Lines, '\n');
 


### PR DESCRIPTION
## What this PR does / why we need it:
The previous implementation depends on the order of VM callback invocation, which is over strict. Now we use map, which has no order restriction. See the comments in code for more information.