### PR TITLE
ci: enable jeandle-llvm checks for performance branch

### DIFF
--- a/.github/workflows/jeandle-llvm-test.yml
+++ b/.github/workflows/jeandle-llvm-test.yml
@@ -5,6 +5,7 @@ on:
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
     branches:
       - 'main'
+      - 'performance'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}


### PR DESCRIPTION
## What this PR does / why we need it:
Add ci test for 'performance' branch