### PR TITLE
enhance: move JeandleInlineDriver after JavaOperationLower0 and add more passes in runRootInstSimplify

### DIFF
--- a/llvm/include/llvm/Transforms/Jeandle/JavaOperationDeletion.h
+++ b/llvm/include/llvm/Transforms/Jeandle/JavaOperationDeletion.h
@@ -1,4 +1,4 @@
-//===- JavaOperationDeletion.h - Erase lowered JavaOps ---------------------------===//
+//===- JavaOperationDeletion.h - Erase lowered JavaOps --------------------===//
 //
 // Copyright (c) 2026, the Jeandle-LLVM Authors. All Rights Reserved.
 //

--- a/llvm/include/llvm/Transforms/Jeandle/JavaOperationDeletion.h
+++ b/llvm/include/llvm/Transforms/Jeandle/JavaOperationDeletion.h
@@ -1,0 +1,36 @@
+//===- JavaOperationDeletion.h - Erase lowered JavaOps ---------------------------===//
+//
+// Copyright (c) 2026, the Jeandle-LLVM Authors. All Rights Reserved.
+//
+// Part of the Jeandle-LLVM project, under the Apache License v2.0 with LLVM
+// Exceptions. See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass erases JavaOp functions (those carrying the "lower-phase" function
+// attribute) once they have been fully lowered by JavaOperationLower and no
+// longer have any users. Deletion is split out of JavaOperationLower so that
+// JavaOp definitions remain alive in the module across the inline driver and
+// the O3 pipeline, which can still resolve JavaOps referenced by replayed
+// inline-callee bodies by name. This pass runs once, late, after the final
+// JavaOperationLower phase.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_JEANDLE_JAVA_OP_DELETION_H
+#define LLVM_JEANDLE_JAVA_OP_DELETION_H
+
+#include "llvm/IR/PassManager.h"
+
+namespace llvm {
+
+class JavaOperationDeletion : public PassInfoMixin<JavaOperationDeletion> {
+public:
+  JavaOperationDeletion() {}
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
+};
+
+} // namespace llvm
+
+#endif // LLVM_JEANDLE_JAVA_OP_DELETION_H

--- a/llvm/lib/Jeandle/Pipeline.cpp
+++ b/llvm/lib/Jeandle/Pipeline.cpp
@@ -11,6 +11,7 @@
 #include "llvm/Jeandle/Pipeline.h"
 #include "llvm/Transforms/Jeandle/ConstantFieldFolding.h"
 #include "llvm/Transforms/Jeandle/InsertGCBarriers.h"
+#include "llvm/Transforms/Jeandle/JavaOperationDeletion.h"
 #include "llvm/Transforms/Jeandle/JavaOperationLower.h"
 #include "llvm/Transforms/Jeandle/JeandleInliner.h"
 #include "llvm/Transforms/Jeandle/RepeatedConstantFolding.h"
@@ -43,6 +44,7 @@ ModulePassManager Pipeline::buildJeandlePipeline(PassBuilder &PB,
                                                  OptimizationLevel level,
                                                  PipelineOptions Options) {
   ModulePassManager PM;
+  PM.addPass(JavaOperationLower(0));
   // JeandleInlineDriver owns the inline-specific loop. Devirtualization
   // refinement between inline rounds should be wired inside the driver so
   // inline-scope state can be preserved across IR rewrites.
@@ -56,14 +58,13 @@ ModulePassManager Pipeline::buildJeandlePipeline(PassBuilder &PB,
     PM.addPass(JeandleInlineDriver(/*InlineAccessorsOnly=*/true));
     break;
   }
-  PM.addPass(JavaOperationLower(0));
   PM.addPass(createModuleToFunctionPassAdaptor(InstSimplifyPass()));
   PM.addPass(createModuleToFunctionPassAdaptor(TypeCheckElimination()));
   PM.addPass(createModuleToFunctionPassAdaptor(RepeatedConstantFolding()));
   PM.addPass(createModuleToFunctionPassAdaptor(TypeCheckElimination()));
   // TODO: InsertGCBarriers currently inserts high-level barrier calls before
-  // O3 because it cannot handle O3 generated memory intrinsics and vector 
-  // instructions. But the uninlined barrier calls can still block useful 
+  // O3 because it cannot handle O3 generated memory intrinsics and vector
+  // instructions. But the uninlined barrier calls can still block useful
   // optimizations.
   PM.addPass(createModuleToFunctionPassAdaptor(InsertGCBarriers()));
   PM.addPass(JavaOperationLower(1));
@@ -84,6 +85,11 @@ ModulePassManager Pipeline::buildJeandlePipeline(PassBuilder &PB,
   // optimization opportunities while keeping raw derived addresses local to the
   // final barrier code.
   PM.addPass(JavaOperationLower(9));
+  // Erase JavaOp definitions that have been fully lowered (user-empty) and are
+  // no longer referenced. This must run after the inline driver and all
+  // JavaOperationLower phases: every JavaOp must stay alive while replayed
+  // callee bodies may still resolve them by name during inlining.
+  PM.addPass(JavaOperationDeletion());
   PM.addPass(createModuleToFunctionPassAdaptor(TLSPointerRewrite()));
   PM.addPass(createModuleToFunctionPassAdaptor(InstSimplifyPass()));
   return PM;

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -268,6 +268,7 @@
 #include "llvm/Transforms/Instrumentation/TypeSanitizer.h"
 #include "llvm/Transforms/Jeandle/ConstantFieldFolding.h"
 #include "llvm/Transforms/Jeandle/InsertGCBarriers.h"
+#include "llvm/Transforms/Jeandle/JavaOperationDeletion.h"
 #include "llvm/Transforms/Jeandle/JavaOperationLower.h"
 #include "llvm/Transforms/Jeandle/JeandleDevirtualization.h"
 #include "llvm/Transforms/Jeandle/JeandleInliner.h"

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -102,6 +102,7 @@ MODULE_PASS("inliner-wrapper-no-mandatory-first",
 MODULE_PASS("jeandle-devirtualization", JeandleDevirtualization())
 MODULE_PASS("jeandle-inline-driver", JeandleInlineDriver())
 MODULE_PASS("jeandle-inliner", JeandleInliner())
+MODULE_PASS("java-operation-deletion", JavaOperationDeletion())
 MODULE_PASS("insert-gcov-profiling", GCOVProfilerPass())
 MODULE_PASS("instrprof", InstrProfilingLoweringPass())
 MODULE_PASS("ctx-instr-lower", PGOCtxProfLoweringPass())

--- a/llvm/lib/Transforms/Jeandle/CMakeLists.txt
+++ b/llvm/lib/Transforms/Jeandle/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_llvm_component_library(LLVMJeandleTransforms
   ConstantFieldFolding.cpp
   InsertGCBarriers.cpp
+  JavaOperationDeletion.cpp
   JavaOperationLower.cpp
   JeandleDevirtualization.cpp
   JeandleInlineDriver.cpp

--- a/llvm/lib/Transforms/Jeandle/JavaOperationDeletion.cpp
+++ b/llvm/lib/Transforms/Jeandle/JavaOperationDeletion.cpp
@@ -21,18 +21,16 @@ using namespace llvm;
 namespace {
 
 // Strip \p F from the @llvm.used global array so it can be erased without
-// leaving a dangling Constant reference that would trip the verifier. Returns
-// true if @llvm.used was modified. Moved here from JavaOperationLower: lowering
-// no longer erases JavaOps, so only this deletion pass needs the helper.
-static bool removeFunctionFromLLVMUsed(Module &M, Function &F) {
+// leaving a dangling Constant reference that would trip the verifier.
+static void removeFunctionFromLLVMUsed(Module &M, Function &F) {
   GlobalVariable *UsedArray = M.getGlobalVariable("llvm.used");
   if (!UsedArray)
-    return false;
+    return;
 
   ConstantArray *InitArray = cast<ConstantArray>(UsedArray->getInitializer());
   if (!InitArray) {
     UsedArray->eraseFromParent();
-    return false;
+    return;
   }
 
   std::vector<Constant *> NewElements;
@@ -51,13 +49,13 @@ static bool removeFunctionFromLLVMUsed(Module &M, Function &F) {
   }
 
   if (!found)
-    return false;
+    return;
 
   UsedArray->eraseFromParent();
 
   // Erase the empty llvm.used directly.
   if (NewElements.empty())
-    return true;
+    return;
 
   // Create a new llvm.used with the preserved elements.
   auto *NewArrayTy = ArrayType::get(InitArray->getType()->getElementType(),
@@ -67,8 +65,6 @@ static bool removeFunctionFromLLVMUsed(Module &M, Function &F) {
       M, NewArrayTy, false, GlobalValue::AppendingLinkage,
       ConstantArray::get(NewArrayTy, NewElements), "llvm.used");
   NewUsedArray->setSection("llvm.metadata");
-
-  return true;
 }
 
 } // end anonymous namespace
@@ -90,20 +86,11 @@ PreservedAnalyses JavaOperationDeletion::run(Module &M,
 
     // Strip @llvm.used first: a lowered JavaOp that no longer has any caller is
     // still referenced by the @llvm.used global, so user_empty() is false until
-    // that reference is removed. This mirrors the order the old
-    // JavaOperationLower used (strip, then check emptiness, then erase). If F
-    // survives (it still has real users) it does not need @llvm.used
-    // protection, since real callers keep it alive against DCE on their own.
-    bool Stripped = removeFunctionFromLLVMUsed(M, F);
+    // that reference is removed.
+    removeFunctionFromLLVMUsed(M, F);
     F.removeDeadConstantUsers();
 
-    // A JavaOp that still has real users (e.g. an un-driven phase, or residual
-    // non-call ConstantExpr/metadata uses) has not been fully lowered. Leave it
-    // in place so we never delete a definition that is still referenced.
-    if (!F.user_empty()) {
-      Changed |= Stripped;
-      continue;
-    }
+    assert(F.user_empty() && "All JavaOps should have no users");
 
     LLVM_DEBUG(dbgs() << "erase lowered JavaOp: " << F.getName() << "\n");
 

--- a/llvm/lib/Transforms/Jeandle/JavaOperationDeletion.cpp
+++ b/llvm/lib/Transforms/Jeandle/JavaOperationDeletion.cpp
@@ -1,0 +1,121 @@
+//===- JavaOperationDeletion.cpp - Erase lowered JavaOps -------------------------===//
+//
+// Copyright (c) 2026, the Jeandle-LLVM Authors. All Rights Reserved.
+//
+// Part of the Jeandle-LLVM project, under the Apache License v2.0 with LLVM
+// Exceptions. See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Transforms/Jeandle/JavaOperationDeletion.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Jeandle/Attributes.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/Debug.h"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "java-operation-deletion"
+
+namespace {
+
+// Strip \p F from the @llvm.used global array so it can be erased without
+// leaving a dangling Constant reference that would trip the verifier. Returns
+// true if @llvm.used was modified. Moved here from JavaOperationLower: lowering
+// no longer erases JavaOps, so only this deletion pass needs the helper.
+static bool removeFunctionFromLLVMUsed(Module &M, Function &F) {
+  GlobalVariable *UsedArray = M.getGlobalVariable("llvm.used");
+  if (!UsedArray)
+    return false;
+
+  ConstantArray *InitArray = cast<ConstantArray>(UsedArray->getInitializer());
+  if (!InitArray) {
+    UsedArray->eraseFromParent();
+    return false;
+  }
+
+  std::vector<Constant *> NewElements;
+  bool found = false;
+
+  // Find all elements to be preserved.
+  for (unsigned i = 0; i < InitArray->getNumOperands(); i++) {
+    Constant *Element = InitArray->getOperand(i);
+    if (Function *Func = dyn_cast<Function>(Element)) {
+      if (Func == &F) {
+        found = true;
+        continue;
+      }
+    }
+    NewElements.push_back(Element);
+  }
+
+  if (!found)
+    return false;
+
+  UsedArray->eraseFromParent();
+
+  // Erase the empty llvm.used directly.
+  if (NewElements.empty())
+    return true;
+
+  // Create a new llvm.used with the preserved elements.
+  auto *NewArrayTy = ArrayType::get(InitArray->getType()->getElementType(),
+                                    NewElements.size());
+
+  auto *NewUsedArray = new GlobalVariable(
+      M, NewArrayTy, false, GlobalValue::AppendingLinkage,
+      ConstantArray::get(NewArrayTy, NewElements), "llvm.used");
+  NewUsedArray->setSection("llvm.metadata");
+
+  return true;
+}
+
+} // end anonymous namespace
+
+PreservedAnalyses JavaOperationDeletion::run(Module &M, ModuleAnalysisManager &MAM) {
+  bool Changed = false;
+  FunctionAnalysisManager &FAM =
+      MAM.getResult<FunctionAnalysisManagerModuleProxy>(M).getManager();
+
+  for (Function &F : make_early_inc_range(M)) {
+    if (!F.hasFnAttribute(jeandle::Attribute::LowerPhase))
+      continue;
+    // JavaOps are definitions; a declaration with a lower-phase attribute would
+    // be malformed input. Skip defensively rather than risk erasing a prototype
+    // that may still be referenced.
+    if (F.isDeclaration())
+      continue;
+
+    // Strip @llvm.used first: a lowered JavaOp that no longer has any caller is
+    // still referenced by the @llvm.used global, so user_empty() is false until
+    // that reference is removed. This mirrors the order the old JavaOperationLower
+    // used (strip, then check emptiness, then erase). If F survives (it still has
+    // real users) it does not need @llvm.used protection, since real callers keep
+    // it alive against DCE on their own.
+    bool Stripped = removeFunctionFromLLVMUsed(M, F);
+    F.removeDeadConstantUsers();
+
+    // A JavaOp that still has real users (e.g. an un-driven phase, or residual
+    // non-call ConstantExpr/metadata uses) has not been fully lowered. Leave it
+    // in place so we never delete a definition that is still referenced.
+    if (!F.user_empty()) {
+      Changed |= Stripped;
+      continue;
+    }
+
+    LLVM_DEBUG(dbgs() << "erase lowered JavaOp: " << F.getName() << "\n");
+
+    FAM.clear(F, F.getName());
+    M.getFunctionList().erase(F);
+    Changed = true;
+  }
+
+  if (!Changed)
+    return PreservedAnalyses::all();
+
+  PreservedAnalyses PA;
+  PA.preserve<FunctionAnalysisManagerModuleProxy>();
+  PA.preserveSet<AllAnalysesOn<Function>>();
+  return PA;
+}

--- a/llvm/lib/Transforms/Jeandle/JavaOperationDeletion.cpp
+++ b/llvm/lib/Transforms/Jeandle/JavaOperationDeletion.cpp
@@ -1,4 +1,4 @@
-//===- JavaOperationDeletion.cpp - Erase lowered JavaOps -------------------------===//
+//===- JavaOperationDeletion.cpp - Erase lowered JavaOps ------------------===//
 //
 // Copyright (c) 2026, the Jeandle-LLVM Authors. All Rights Reserved.
 //
@@ -73,7 +73,8 @@ static bool removeFunctionFromLLVMUsed(Module &M, Function &F) {
 
 } // end anonymous namespace
 
-PreservedAnalyses JavaOperationDeletion::run(Module &M, ModuleAnalysisManager &MAM) {
+PreservedAnalyses JavaOperationDeletion::run(Module &M,
+                                             ModuleAnalysisManager &MAM) {
   bool Changed = false;
   FunctionAnalysisManager &FAM =
       MAM.getResult<FunctionAnalysisManagerModuleProxy>(M).getManager();
@@ -89,10 +90,10 @@ PreservedAnalyses JavaOperationDeletion::run(Module &M, ModuleAnalysisManager &M
 
     // Strip @llvm.used first: a lowered JavaOp that no longer has any caller is
     // still referenced by the @llvm.used global, so user_empty() is false until
-    // that reference is removed. This mirrors the order the old JavaOperationLower
-    // used (strip, then check emptiness, then erase). If F survives (it still has
-    // real users) it does not need @llvm.used protection, since real callers keep
-    // it alive against DCE on their own.
+    // that reference is removed. This mirrors the order the old
+    // JavaOperationLower used (strip, then check emptiness, then erase). If F
+    // survives (it still has real users) it does not need @llvm.used
+    // protection, since real callers keep it alive against DCE on their own.
     bool Stripped = removeFunctionFromLLVMUsed(M, F);
     F.removeDeadConstantUsers();
 

--- a/llvm/lib/Transforms/Jeandle/JavaOperationLower.cpp
+++ b/llvm/lib/Transforms/Jeandle/JavaOperationLower.cpp
@@ -26,53 +26,6 @@ using namespace llvm;
 
 namespace {
 
-static bool removeFunctionFromLLVMUsed(Module &M, Function &F) {
-  GlobalVariable *UsedArray = M.getGlobalVariable("llvm.used");
-  if (!UsedArray)
-    return false;
-
-  ConstantArray *InitArray = cast<ConstantArray>(UsedArray->getInitializer());
-  if (!InitArray) {
-    UsedArray->eraseFromParent();
-    return false;
-  }
-
-  std::vector<Constant *> NewElements;
-  bool found = false;
-
-  // Find all elements to be preserved.
-  for (unsigned i = 0; i < InitArray->getNumOperands(); i++) {
-    Constant *Element = InitArray->getOperand(i);
-    if (Function *Func = dyn_cast<Function>(Element)) {
-      if (Func == &F) {
-        found = true;
-        continue;
-      }
-    }
-    NewElements.push_back(Element);
-  }
-
-  if (!found)
-    return false;
-
-  UsedArray->eraseFromParent();
-
-  // Erase the empty llvm.used directly.
-  if (NewElements.empty())
-    return true;
-
-  // Create a new llvm.used with the preserved elements.
-  auto *NewArrayTy = ArrayType::get(InitArray->getType()->getElementType(),
-                                    NewElements.size());
-
-  auto *NewUsedArray = new GlobalVariable(
-      M, NewArrayTy, false, GlobalValue::AppendingLinkage,
-      ConstantArray::get(NewArrayTy, NewElements), "llvm.used");
-  NewUsedArray->setSection("llvm.metadata");
-
-  return true;
-}
-
 static bool
 runImpl(Module &M, int Phase, FunctionAnalysisManager *FAM,
         function_ref<AAResults &(Function &)> GetAAR, ProfileSummaryInfo &PSI,
@@ -95,17 +48,19 @@ runImpl(Module &M, int Phase, FunctionAnalysisManager *FAM,
     if (!shouldInline(F))
       continue;
 
+    // Already lowered by a prior JavaOperationLower run: it has no remaining
+    // call sites to inline. Skip it so repeated in-driver invocations do not
+    // re-iterate already-lowered JavaOps. The JavaOp definition itself is left
+    // in the module for a later JavaOperationDeletion pass to erase.
+    if (F.user_empty())
+      continue;
+
     assert(!F.isPresplitCoroutine() &&
            "A presplit coroutine function should not be a JavaOp");
     assert(!F.isDeclaration() &&
            "A function declaration should not be a JavaOp");
     assert(isInlineViable(F).isSuccess() &&
            "Function should be viable for inlining");
-
-    if (removeFunctionFromLLVMUsed(M, F)) {
-      LLVM_DEBUG(dbgs() << "remove function:" << F.getName() << "from llvm.used"
-                        << " in lower phase: " << Phase << "\n");
-    }
 
     Calls.clear();
     for (User *U : F.users())
@@ -125,22 +80,11 @@ runImpl(Module &M, int Phase, FunctionAnalysisManager *FAM,
         continue;
       }
 
+      Changed = true;
+
       if (FAM)
         FAM->invalidate(*Caller, PreservedAnalyses::none());
     }
-
-    F.removeDeadConstantUsers();
-
-    assert(F.user_empty() && "JavaOp should not be used after lowering");
-
-    if (FAM)
-      FAM->clear(F, F.getName());
-    M.getFunctionList().erase(F);
-
-    LLVM_DEBUG(dbgs() << "remove lowered JavaOp: " << F.getName()
-                      << " in lower phase: " << Phase << "\n");
-
-    Changed = true;
   }
   return Changed;
 }
@@ -165,7 +109,12 @@ PreservedAnalyses JavaOperationLower::run(Module &M,
     return PreservedAnalyses::all();
 
   PreservedAnalyses PA;
-  // We have already invalidated all analyses on modified functions.
+  // runImpl eagerly invalidated every caller it inlined a JavaOp into, so keep
+  // the FAM proxy alive (mirrors ModuleToFunctionPassAdaptor and the inline
+  // round) instead of letting the outer module manager nuke all function
+  // analyses. The proxy's deferred outer-invalidation still propagates any
+  // module-analysis invalidation to dependent function analyses.
+  PA.preserve<FunctionAnalysisManagerModuleProxy>();
   PA.preserveSet<AllAnalysesOn<Function>>();
   return PA;
 }

--- a/llvm/lib/Transforms/Jeandle/JeandleInlineDriver.cpp
+++ b/llvm/lib/Transforms/Jeandle/JeandleInlineDriver.cpp
@@ -237,8 +237,8 @@ PreservedAnalyses JeandleInlineDriver::run(Module &M,
       // Lower phase-0 JavaOp call sites exposed by the previous inline round's
       // inlining.
       PreservedAnalyses JavaOpLowerPA = JavaOperationLower(0).run(M, MAM);
-      updateDriverPreservedAnalyses(M, MAM, DriverPA, std::move(JavaOpLowerPA));
       Changed |= !JavaOpLowerPA.areAllPreserved();
+      updateDriverPreservedAnalyses(M, MAM, DriverPA, std::move(JavaOpLowerPA));
 
       // Per-round cleanup.
       PreservedAnalyses CleanupPA = runRootInstSimplify(M, MAM);

--- a/llvm/lib/Transforms/Jeandle/JeandleInlineDriver.cpp
+++ b/llvm/lib/Transforms/Jeandle/JeandleInlineDriver.cpp
@@ -169,11 +169,8 @@ static PreservedAnalyses runRootInstSimplify(Module &M,
   FPM.addPass(InstCombinePass());
   FPM.addPass(SimplifyCFGPass());
   FPM.addPass(ADCEPass());
+
   PreservedAnalyses RootPA = FPM.run(*RootFunction, FAM);
-  // FPM.run already invalidated root's analyses per-pass internally, so
-  // RootPA is consumed only for the Changed flag; the combined PA returned
-  // below relies on that per-pass invalidation plus JavaOpLower's eager
-  // per-caller invalidation.
   Changed |= !RootPA.areAllPreserved();
 
   if (!Changed)

--- a/llvm/lib/Transforms/Jeandle/JeandleInlineDriver.cpp
+++ b/llvm/lib/Transforms/Jeandle/JeandleInlineDriver.cpp
@@ -37,7 +37,13 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Jeandle/JeandleDevirtualization.h"
+#include "llvm/Transforms/Jeandle/JavaOperationLower.h"
+#include "llvm/Transforms/Jeandle/TypeCheckElimination.h"
+#include "llvm/Transforms/InstCombine/InstCombine.h"
+#include "llvm/Transforms/Scalar/ADCE.h"
+#include "llvm/Transforms/Scalar/EarlyCSE.h"
 #include "llvm/Transforms/Scalar/InstSimplifyPass.h"
+#include "llvm/Transforms/Scalar/SimplifyCFG.h"
 
 #include <string>
 #include <utility>
@@ -137,26 +143,44 @@ static constexpr unsigned MaxInlineDriverIterations = 512;
 
 static PreservedAnalyses runRootInstSimplify(Module &M,
                                              ModuleAnalysisManager &MAM) {
+  bool Changed = false;
   Function *RootFunction = getRootJavaMethodFunction(M);
-  if (!RootFunction)
+  if (!RootFunction) {
     return PreservedAnalyses::all();
+  }
 
   FunctionAnalysisManager &FAM =
       MAM.getResult<FunctionAnalysisManagerModuleProxy>(M).getManager();
 
-  PreservedAnalyses FunctionPA = InstSimplifyPass().run(*RootFunction, FAM);
-  if (FunctionPA.areAllPreserved())
+  // Per-round root cleanup, mirroring the O3 "simplify after inline" cleanup.
+  //   - InstSimplify: cheap local instruction folding, no CFG rewrite.
+  //   - TypeCheckElimination: fold jeandle.check_instanceof to constants,
+  //     exposing monomorphic call sites for the next devirtualization round.
+  //   - EarlyCSE: common-subexpression elimination (also load CSE), removes
+  //     redundant computation.
+  //   - InstCombine: instruction simplification + constant folding/
+  //     propagation, and removal of dead instructions.
+  //   - SimplifyCFG: remove unreachable blocks, merge blocks, fold branches.
+  //   - ADCE: aggressive dead-code elimination.
+  FunctionPassManager FPM;
+  FPM.addPass(InstSimplifyPass());
+  FPM.addPass(TypeCheckElimination());
+  FPM.addPass(EarlyCSEPass());
+  FPM.addPass(InstCombinePass());
+  FPM.addPass(SimplifyCFGPass());
+  FPM.addPass(ADCEPass());
+  PreservedAnalyses RootPA = FPM.run(*RootFunction, FAM);
+  // FPM.run already invalidated root's analyses per-pass internally, so
+  // RootPA is consumed only for the Changed flag; the combined PA returned
+  // below relies on that per-pass invalidation plus JavaOpLower's eager
+  // per-caller invalidation.
+  Changed |= !RootPA.areAllPreserved();
+
+  if (!Changed)
     return PreservedAnalyses::all();
 
-  FAM.invalidate(*RootFunction, FunctionPA);
-
-  PreservedAnalyses PA;
-  // InstSimplify only runs on the root function here. Its function analyses
-  // have already been invalidated with the pass result above, so keep the FAM
-  // proxy and unrelated function-analysis caches alive for the module manager.
-  PA.preserve<FunctionAnalysisManagerModuleProxy>();
-  PA.preserveSet<AllAnalysesOn<Function>>();
-  return PA;
+  RootPA.preserve<FunctionAnalysisManagerModuleProxy>();
+  return RootPA;
 }
 
 PreservedAnalyses JeandleInlineDriver::run(Module &M,
@@ -189,32 +213,45 @@ PreservedAnalyses JeandleInlineDriver::run(Module &M,
   // Loop shape:
   //   1. Run one inline round. The round tags every newly exposed call site
   //      with inline-scope-id metadata.
-  //   2. If the inline round did not expose any new call sites, stop.
-  //   3. Run devirtualization refinement. It must propagate inline-scope-id
+  //   2. Per-round cleanup (runRootInstSimplify): lower the phase-0 JavaOp
+  //      calls exposed by this round and simplify the root. Runs even when the
+  //      round exposed no new *monomorphic* call sites, so a callee body that
+  //      only brought in phase-0 JavaOp calls still gets them lowered.
+  //   3. If the inline round did not expose any new call sites, stop.
+  //   4. Run devirtualization refinement. It must propagate inline-scope-id
   //      and deopt/BCI information when it clones or replaces calls.
-  //   4. If devirtualization preserved everything, it did not produce a new
+  //   5. If devirtualization preserved everything, it did not produce a new
   //      MonomorphicTarget call site and the loop stops; otherwise rescan IR
   //      in the next inline round.
   bool HitIterationLimit = true;
   for (unsigned Iteration = 0; Iteration < MaxInlineDriverIterations;
        ++Iteration) {
+
+    // Inline one round.
     InlineRoundResult InlineResult =
         Inliner.runInlineRound(M, MAM, InlineScopes);
-    Changed |= !InlineResult.PA.areAllPreserved();
-    updateDriverPreservedAnalyses(M, MAM, DriverPA, std::move(InlineResult.PA));
+    bool RoundChanged = !InlineResult.PA.areAllPreserved();
+    Changed |= RoundChanged;
+
+    if (RoundChanged) {
+      updateDriverPreservedAnalyses(M, MAM, DriverPA, std::move(InlineResult.PA));
+
+      // Lower phase-0 JavaOp call sites exposed by the previous inline round's
+      // inlining.
+      PreservedAnalyses JavaOpLowerPA = JavaOperationLower(0).run(M, MAM);
+      updateDriverPreservedAnalyses(M, MAM, DriverPA, std::move(JavaOpLowerPA));
+      Changed |= !JavaOpLowerPA.areAllPreserved();
+
+      // Per-round cleanup.
+      PreservedAnalyses CleanupPA = runRootInstSimplify(M, MAM);
+      Changed |= !CleanupPA.areAllPreserved();
+      updateDriverPreservedAnalyses(M, MAM, DriverPA, std::move(CleanupPA));
+    }
 
     if (!InlineResult.ExposedNewCallSites) {
       HitIterationLimit = false;
       break;
     }
-
-    // Keep the per-round cleanup conservative: InstSimplify performs local
-    // instruction simplification without introducing new instructions or
-    // rewriting the CFG. Run it before devirtualization so newly exposed call
-    // sites are seen after cheap local folding.
-    PreservedAnalyses SimplifyPA = runRootInstSimplify(M, MAM);
-    Changed |= !SimplifyPA.areAllPreserved();
-    updateDriverPreservedAnalyses(M, MAM, DriverPA, std::move(SimplifyPA));
 
     PreservedAnalyses DevirtPA = Devirtualization.runDevirtualization(M, MAM);
     bool AddedMonomorphicTargets = !DevirtPA.areAllPreserved();

--- a/llvm/lib/Transforms/Jeandle/JeandleInlineDriver.cpp
+++ b/llvm/lib/Transforms/Jeandle/JeandleInlineDriver.cpp
@@ -36,10 +36,10 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/Transforms/Jeandle/JeandleDevirtualization.h"
-#include "llvm/Transforms/Jeandle/JavaOperationLower.h"
-#include "llvm/Transforms/Jeandle/TypeCheckElimination.h"
 #include "llvm/Transforms/InstCombine/InstCombine.h"
+#include "llvm/Transforms/Jeandle/JavaOperationLower.h"
+#include "llvm/Transforms/Jeandle/JeandleDevirtualization.h"
+#include "llvm/Transforms/Jeandle/TypeCheckElimination.h"
 #include "llvm/Transforms/Scalar/ADCE.h"
 #include "llvm/Transforms/Scalar/EarlyCSE.h"
 #include "llvm/Transforms/Scalar/InstSimplifyPass.h"
@@ -231,7 +231,8 @@ PreservedAnalyses JeandleInlineDriver::run(Module &M,
     Changed |= RoundChanged;
 
     if (RoundChanged) {
-      updateDriverPreservedAnalyses(M, MAM, DriverPA, std::move(InlineResult.PA));
+      updateDriverPreservedAnalyses(M, MAM, DriverPA,
+                                    std::move(InlineResult.PA));
 
       // Lower phase-0 JavaOp call sites exposed by the previous inline round's
       // inlining.

--- a/llvm/test/Jeandle/inline/Inputs/javaop-lowering-in-driver.cblog
+++ b/llvm/test/Jeandle/inline/Inputs/javaop-lowering-in-driver.cblog
@@ -1,0 +1,4 @@
+IsOkToInline -1 0 101 = true
+GetInlineCalleeIR 101 = true
+RecordInlineSuccess -1 0 101 = true
+RecordInliningComplete = true

--- a/llvm/test/Jeandle/inline/Inputs/javaop-lowering-in-driver_inline_callees.ll
+++ b/llvm/test/Jeandle/inline/Inputs/javaop-lowering-in-driver_inline_callees.ll
@@ -1,0 +1,14 @@
+@jeandle.personality = global ptr null
+
+declare hotspotcc i32 @jeandle.example_op() #1
+
+define available_externally hotspotcc i32 @callee_example() #0 gc "hotspotgc" personality ptr @jeandle.personality {
+entry:
+  %r = call i32 @jeandle.example_op()
+  ret i32 %r
+}
+
+attributes #0 = { "java-method"="101" }
+attributes #1 = { "lower-phase"="0" "noinline" }
+
+!java-method-compilation = !{}

--- a/llvm/test/Jeandle/inline/exception-handling.ll
+++ b/llvm/test/Jeandle/inline/exception-handling.ll
@@ -35,8 +35,10 @@ attributes #2 = { "monomorphic-target" }
 ; CHECK-NEXT: to label %{{.*}} unwind label %[[UNWIND:.*]]
 ; CHECK-NOT: @callee_with_eh
 ; CHECK: [[UNWIND]]:
-; CHECK: landingpad i64
-; CHECK: ret i32 42
-; CHECK: unwind.body:
-; CHECK: ret i32 -1
+; CHECK-NEXT: %{{.*}} = landingpad i64
+; CHECK: br label %{{.*}}
+; CHECK: phi i32 [ -1, %{{.*}} ], [ 42, %{{.*}} ]
+; CHECK: ret i32
+; CHECK: declare hotspotcc void @leaf_may_throw()
+; CHECK-NOT: @callee_with_eh
 ; CHECK-NOT: define available_externally hotspotcc i32 @callee_with_eh

--- a/llvm/test/Jeandle/inline/javaop-lowering-in-driver.ll
+++ b/llvm/test/Jeandle/inline/javaop-lowering-in-driver.ll
@@ -1,0 +1,42 @@
+; RUN: opt -S -passes=jeandle-inline-driver -jeandle-vm-callback-log=%S/Inputs/javaop-lowering-in-driver.cblog %s 2>&1 | FileCheck %s
+
+; Verify the inline driver lowers phase-0 JavaOp calls introduced by an inlined
+; callee body. @callee_example is inlined into @root; the in-driver
+; JavaOperationLower(0) round then lowers the new call to the phase-0 JavaOp
+; @jeandle.example_op, so @root ends up with the JavaOp body inlined and no
+; call to it. The JavaOp definition itself remains in the module: the driver
+; does not erase JavaOps (deletion is deferred to the JavaOperationDeletion pass,
+; which the driver does not run).
+
+@jeandle.personality = global ptr null
+
+define hotspotcc i32 @root() #0 gc "hotspotgc" personality ptr @jeandle.personality {
+entry:
+  %OrigPcSlot = alloca i64, align 8
+  %result = call hotspotcc i32 @callee_example() #2 [ "deopt"(i32 0, i32 0, i64 327695, ptr %OrigPcSlot) ]
+  ret i32 %result
+}
+
+declare hotspotcc i32 @callee_example() #1 gc "hotspotgc"
+
+; A phase-0 JavaOp whose body the in-driver JavaOperationLower(0) inlines into
+; @root once @callee_example is inlined there.
+define private hotspotcc i32 @jeandle.example_op() #3 {
+  ret i32 4242
+}
+
+attributes #0 = { "java-method"="1" }
+attributes #1 = { "java-method"="101" }
+attributes #2 = { "monomorphic-target" }
+attributes #3 = { "lower-phase"="0" "noinline" }
+
+!java-method-compilation = !{}
+
+; CHECK-LABEL: define hotspotcc i32 @root(
+; The inlined JavaOp call is gone from @root, replaced by its body.
+; CHECK-NOT: call {{.*}} @jeandle.example_op
+; CHECK: 4242
+; The phase-0 JavaOp definition survives the driver (deletion is deferred).
+; CHECK: define private hotspotcc i32 @jeandle.example_op
+; The available_externally callee body is cleaned up by the driver.
+; CHECK-NOT: define available_externally hotspotcc i32 @callee_example

--- a/llvm/test/Jeandle/inline/resume.ll
+++ b/llvm/test/Jeandle/inline/resume.ll
@@ -39,16 +39,11 @@ attributes #3 = { "monomorphic-target" }
 ; CHECK-NOT: @callee_resume_landingpad
 ; CHECK: invoke hotspotcc void @leaf_resume_landingpad()
 ; CHECK-NEXT: to label %{{.*}} unwind label %[[INNER_UNWIND:.*]]
-; CHECK-NOT: @callee_resume_landingpad
 ; CHECK: [[INNER_UNWIND]]:
-; CHECK: landingpad i64
-; CHECK: br label %root_unwind
-; CHECK: after_landingpad:
-; CHECK-NEXT: br label %root_unwind
-; CHECK: root_unwind:
-; CHECK: landingpad i64
-; CHECK: root_unwind.body1:
-; CHECK-NOT: phi i64
+; CHECK-NEXT: %{{.*}} = landingpad i64
+; CHECK: br label %{{.*}}
 ; CHECK: ret i32 -1
+; CHECK-NOT: @callee_resume_landingpad
+; CHECK-NOT: @callee_resume_zero
 ; CHECK-NOT: define available_externally hotspotcc void @callee_resume_landingpad
 ; CHECK-NOT: define available_externally hotspotcc void @callee_resume_zero

--- a/llvm/test/Jeandle/java-operation-deletion.ll
+++ b/llvm/test/Jeandle/java-operation-deletion.ll
@@ -1,22 +1,15 @@
 ; RUN: opt -S -passes="java-operation-lower<phase=0>,java-operation-deletion" %s 2>&1 | FileCheck %s
 
-; This is just a test to verify JavaOperationDeletion can delete all unused JavaOps.
-; In the real Jeandle pipeline, we run JavaOperationDeletion after the last JavaOperationLower,
-; so it can delete all JavaOps.
-
 ; Verify JavaOperationDeletion:
 ;   - erases fully-lowered (user-empty) phase-0 JavaOps (gone0, gone1),
-;   - strips them from @llvm.used and removes the now-empty @llvm.used global,
-;   - leaves a JavaOp that still has a real caller (kept0, phase 1, not driven by
-;     phase=0 lowering) in place.
+;   - strips them from @llvm.used and removes the now-empty @llvm.used global.
 
-@llvm.used = appending global [3 x ptr] [ptr @gone0, ptr @gone1, ptr @kept0], section "llvm.metadata"
+@llvm.used = appending global [1 x ptr] [ptr @gone0], section "llvm.metadata"
 
 define hotspotcc i32 @root(ptr addrspace(1) %p) #0 gc "hotspotgc" {
 entry:
   %a = call i32 @gone0(i32 1, ptr addrspace(1) %p)
-  %b = call i32 @kept0(i32 2, ptr addrspace(1) %p)
-  ret i32 %b
+  ret i32 %a
 }
 
 ; gone0 is phase=0, called once by root. phase=0 lowering inlines it into root;
@@ -32,18 +25,10 @@ define i32 @gone1(i32 %x, ptr addrspace(1) %p) #1 {
   ret i32 %y
 }
 
-; kept0 is phase=1, not driven by phase=0 lowering. root still calls it, so it has
-; a real user. Deletion must leave it defined.
-define i32 @kept0(i32 %x, ptr addrspace(1) %p) #2 {
-  ret i32 %x
-}
-
 attributes #0 = { "noinline" }
 attributes #1 = { "lower-phase"="0" "noinline" }
-attributes #2 = { "lower-phase"="1" "noinline" }
 
 ; CHECK: define hotspotcc i32 @root
 ; CHECK-NOT: @gone0
 ; CHECK-NOT: @gone1
-; CHECK: define i32 @kept0
 ; CHECK-NOT: @llvm.used = appending global

--- a/llvm/test/Jeandle/java-operation-deletion.ll
+++ b/llvm/test/Jeandle/java-operation-deletion.ll
@@ -1,0 +1,45 @@
+; RUN: opt -S -passes="java-operation-lower<phase=0>,java-operation-deletion" %s 2>&1 | FileCheck %s
+
+; Verify JavaOperationDeletion:
+;   - erases fully-lowered (user-empty) phase-0 JavaOps (gone0, gone1),
+;   - strips them from @llvm.used and removes the now-empty @llvm.used global,
+;   - leaves a JavaOp that still has a real caller (kept0, phase 1, not driven by
+;     phase=0 lowering) in place.
+
+@llvm.used = appending global [3 x ptr] [ptr @gone0, ptr @gone1, ptr @kept0], section "llvm.metadata"
+
+define hotspotcc i32 @root(ptr addrspace(1) %p) #0 gc "hotspotgc" {
+entry:
+  %a = call i32 @gone0(i32 1, ptr addrspace(1) %p)
+  %b = call i32 @kept0(i32 2, ptr addrspace(1) %p)
+  ret i32 %b
+}
+
+; gone0 is phase=0, called once by root. phase=0 lowering inlines it into root;
+; it then has no callers (only @llvm.used). Deletion strips @llvm.used and erases.
+define i32 @gone0(i32 %x, ptr addrspace(1) %p) #1 {
+  ret i32 %x
+}
+
+; gone1 is phase=0, called by gone0. phase=0 lowering transitively inlines gone0
+; into gone1; gone1 itself has no callers. Deletion erases it.
+define i32 @gone1(i32 %x, ptr addrspace(1) %p) #1 {
+  %y = call i32 @gone0(i32 %x, ptr addrspace(1) %p)
+  ret i32 %y
+}
+
+; kept0 is phase=1, not driven by phase=0 lowering. root still calls it, so it has
+; a real user. Deletion must leave it defined.
+define i32 @kept0(i32 %x, ptr addrspace(1) %p) #2 {
+  ret i32 %x
+}
+
+attributes #0 = { "noinline" }
+attributes #1 = { "lower-phase"="0" "noinline" }
+attributes #2 = { "lower-phase"="1" "noinline" }
+
+; CHECK: define hotspotcc i32 @root
+; CHECK-NOT: @gone0
+; CHECK-NOT: @gone1
+; CHECK: define i32 @kept0
+; CHECK-NOT: @llvm.used = appending global

--- a/llvm/test/Jeandle/java-operation-deletion.ll
+++ b/llvm/test/Jeandle/java-operation-deletion.ll
@@ -1,5 +1,9 @@
 ; RUN: opt -S -passes="java-operation-lower<phase=0>,java-operation-deletion" %s 2>&1 | FileCheck %s
 
+; This is just a test to verify JavaOperationDeletion can delete all unused JavaOps.
+; In the real Jeandle pipeline, we run JavaOperationDeletion after the last JavaOperationLower,
+; so it can delete all JavaOps.
+
 ; Verify JavaOperationDeletion:
 ;   - erases fully-lowered (user-empty) phase-0 JavaOps (gone0, gone1),
 ;   - strips them from @llvm.used and removes the now-empty @llvm.used global,
@@ -21,7 +25,7 @@ define i32 @gone0(i32 %x, ptr addrspace(1) %p) #1 {
   ret i32 %x
 }
 
-; gone1 is phase=0, called by gone0. phase=0 lowering transitively inlines gone0
+; gone1 is phase=0 and calls gone0. phase=0 lowering transitively inlines gone0
 ; into gone1; gone1 itself has no callers. Deletion erases it.
 define i32 @gone1(i32 %x, ptr addrspace(1) %p) #1 {
   %y = call i32 @gone0(i32 %x, ptr addrspace(1) %p)

--- a/llvm/test/Jeandle/java-operation-lower.ll
+++ b/llvm/test/Jeandle/java-operation-lower.ll
@@ -1,4 +1,4 @@
-; RUN: opt -S -passes="java-operation-lower<phase=0>" %s 2>&1 | FileCheck %s
+; RUN: opt -S -passes="java-operation-lower<phase=0>,java-operation-deletion" %s 2>&1 | FileCheck %s
 
 ; CHECK-NOT: call i32 @test0(i32 7, ptr addrspace(1) %0)
 ; CHECK-NOT: define i32 @test0

--- a/llvm/test/Jeandle/java-operation-lower.ll
+++ b/llvm/test/Jeandle/java-operation-lower.ll
@@ -1,4 +1,4 @@
-; RUN: opt -S -passes="java-operation-lower<phase=0>,java-operation-deletion" %s 2>&1 | FileCheck %s
+; RUN: opt -S -passes="java-operation-lower<phase=0>" %s 2>&1 | FileCheck %s
 
 ; CHECK-NOT: call i32 @test0(i32 7, ptr addrspace(1) %0)
 ; CHECK-NOT: define i32 @test0

--- a/llvm/test/Jeandle/lately-use-cross-default-opt.ll
+++ b/llvm/test/Jeandle/lately-use-cross-default-opt.ll
@@ -1,5 +1,5 @@
 ; RUN: opt -S -passes="java-operation-lower<phase=0>,default<O3>,insert-gc-barriers" %s 2>&1 | FileCheck -check-prefix=CHECK-USE %s
-; RUN: opt -S -passes="java-operation-lower<phase=0>,default<O3>,insert-gc-barriers,java-operation-lower<phase=1>" %s 2>&1 | FileCheck -check-prefix=CHECK-ERASE %s
+; RUN: opt -S -passes="java-operation-lower<phase=0>,default<O3>,insert-gc-barriers,java-operation-lower<phase=1>,java-operation-deletion" %s 2>&1 | FileCheck -check-prefix=CHECK-ERASE %s
 
 ; CHECK-USE: @llvm.used = appending global
 ; CHECK-USE: define hotspotcc void @test_gc_write_barrier

--- a/llvm/test/Jeandle/opt-option.ll
+++ b/llvm/test/Jeandle/opt-option.ll
@@ -1,6 +1,6 @@
 ; RUN: opt -S --jeandle --print-pipeline-passes %s 2>&1 | FileCheck %s
 
-; CHECK: {{.*java-operation-lower\<phase=0\>.*constant-field-folding.*java-operation-lower\<phase=1\>.*rewrite-statepoints-for-gc.*java-operation-lower\<phase=9\>.*tls-pointer-rewrite.*instsimplify.*}}
+; CHECK: {{.*java-operation-lower\<phase=0\>.*jeandle-inline-driver.*constant-field-folding.*java-operation-lower\<phase=1\>.*rewrite-statepoints-for-gc.*java-operation-lower\<phase=9\>.*java-operation-deletion.*tls-pointer-rewrite.*instsimplify.*}}
 
 define hotspotcc void @opt_option() {
 entry:


### PR DESCRIPTION
## What this PR does / why we need it:
Move JeandleInlineDriver after JavaOperationLower<0> then we can add passes which rely on JavaOperationLower<0> to runRootInstSimplify, making the runRootInstSimplify more powerful.