### PR TITLE
fix: treat oop arguments as opaque in constant field folding

### DIFF
--- a/llvm/lib/Transforms/Jeandle/ConstantFieldFolding.cpp
+++ b/llvm/lib/Transforms/Jeandle/ConstantFieldFolding.cpp
@@ -196,6 +196,17 @@ DenseMap<Value *, int> computeConstOops(Function &F) {
   DenseMap<Value *, ConstOopLattice> States;
   SmallVector<Value *, 32> Worklist;
 
+  // Oop-typed arguments are opaque producers. Do not rely only on
+  // getLattice's fallback for them: arguments have users, and pushing them is
+  // what forces forwarders such as freeze/cast/select/phi to re-evaluate from
+  // Top to Bottom when their source is an argument.
+  for (Argument &Arg : F.args()) {
+    if (isJavaOopType(Arg.getType())) {
+      States[&Arg] = ConstOopLattice::bottom();
+      Worklist.push_back(&Arg);
+    }
+  }
+
   // Seed three categories of oop-typed Instructions:
   //   source     — load from oop_handle_*  → Constant{Id}, pushed
   //   forwarder  — PHI / Select / cast / freeze / zero-GEP / invariant.group
@@ -204,8 +215,9 @@ DenseMap<Value *, int> computeConstOops(Function &F) {
   //   opaque     — any other oop-typed instruction (calls, non-source loads,
   //                atomic ops, etc.)       → Bottom, pushed
   //
-  // Non-Instruction oop values (Argument, Constant) remain implicitly Bottom
-  // via getLattice's fallback — they have no def site to push from.
+  // Other non-instruction oop values (e.g. Constants) remain implicitly Bottom
+  // via getLattice's fallback; unlike Arguments, they do not need a def-site
+  // worklist seed for this analysis.
   for (BasicBlock &BB : F) {
     for (Instruction &I : BB) {
       if (auto *LI = dyn_cast<LoadInst>(&I)) {

--- a/llvm/test/Jeandle/constant-field-folding/Inputs/field-phi-argument-mixed.cblog
+++ b/llvm/test/Jeandle/constant-field-folding/Inputs/field-phi-argument-mixed.cblog
@@ -1,0 +1,2 @@
+GetConstantFieldInfo 0 12 = 10
+GetConstantFieldValue 0 12 = 42

--- a/llvm/test/Jeandle/constant-field-folding/field-phi-argument-mixed.ll
+++ b/llvm/test/Jeandle/constant-field-folding/field-phi-argument-mixed.ll
@@ -1,0 +1,46 @@
+; RUN: opt -S -passes="constant-field-folding" -jeandle-vm-callback-log=%S/Inputs/field-phi-argument-mixed.cblog %s 2>&1 | FileCheck %s
+
+; An oop-typed argument is an opaque producer. Even if it flows through
+; PHIs and is later merged with a constant oop, the merged value must not be
+; treated as the constant oop. Otherwise CFF may fold a field load from a
+; runtime argument as if it came from @oop_handle_Test_0.
+
+@oop_handle_Test_0 = external global ptr addrspace(1)
+
+define i32 @test(ptr addrspace(1) %arg0, ptr addrspace(1) %arg1,
+                 i1 %choose.arg, i1 %choose.const) gc "hotspotgc" {
+entry:
+  br i1 %choose.arg, label %arg.left, label %arg.right
+
+arg.left:
+  br label %arg.merge
+
+arg.right:
+  br label %arg.merge
+
+arg.merge:
+  %arg.obj = phi ptr addrspace(1) [ %arg0, %arg.left ], [ %arg1, %arg.right ]
+  br i1 %choose.const, label %const.path, label %arg.path
+
+const.path:
+  %const.obj = load ptr addrspace(1), ptr @oop_handle_Test_0
+  br label %merge
+
+arg.path:
+  br label %merge
+
+merge:
+  %merged = phi ptr addrspace(1) [ %const.obj, %const.path ], [ %arg.obj, %arg.path ]
+  %addr = getelementptr i8, ptr addrspace(1) %merged, i64 12
+  %value = load i32, ptr addrspace(1) %addr
+  ret i32 %value
+}
+
+; CHECK-LABEL: define i32 @test(
+; CHECK: %arg.obj = phi
+; CHECK: %merged = phi
+; CHECK: %addr = getelementptr
+; CHECK: %value = load i32, ptr addrspace(1) %addr
+; CHECK: ret i32 %value
+
+!java-method-compilation = !{}


### PR DESCRIPTION
## Related issue(s):

issue #81

## What this PR does / why we need it:

Seed oop-typed function arguments as Bottom in the ConstOop lattice. Arguments
are opaque producers in the current function context, so relying only on the
fallback path can leave argument-derived forwarders at Top and let them be
incorrectly merged with a constant oop.

This prevents mixed PHI chains such as:
```
  %arg.obj = phi [ %arg0, ... ], [ %arg1, ... ]
  %const.obj = load @oop_handle_Const
  %merged = phi [ %const.obj, ... ], [ %arg.obj, ... ]
  %value = load (%merged + field_offset)
```
from being folded as if %merged were always %const.obj.

Also add a regression test where an oop argument flows through PHIs and is
merged with an oop_handle constant. The field load must remain a load instead
of being folded to the constant oop's field value.