### PR TITLE
fix: include should_reexecute flag in synthetic narrow-oop deopt bundle

### DIFF
--- a/llvm/lib/Transforms/Jeandle/JeandleNarrowOopMarker.cpp
+++ b/llvm/lib/Transforms/Jeandle/JeandleNarrowOopMarker.cpp
@@ -91,9 +91,14 @@ PreservedAnalyses JeandleNarrowOopMarker::run(Function &F,
       // should_reexecute flag before the duplicated-bci pair. A synthetic
       // bundle must include it too, or the reader misinterprets this bci
       // as should_reexecute and desyncs every value after it.
-      Value *SyntheticShouldReexecute = ConstantInt::get(Type::getInt32Ty(Ctx), 0);
+      //
+      // should_reexecute is i64 (see JeandleAbstractInterpreter::deopt_args)
+      // so it can't be mistaken for one half of the duplicated-bci i32 pair.
+      Value *SyntheticShouldReexecute =
+          ConstantInt::get(Type::getInt64Ty(Ctx), 0);
       Value *SyntheticBci = ConstantInt::get(Type::getInt32Ty(Ctx), -1);
-      DeoptInputs.insert(DeoptInputs.begin(), {SyntheticShouldReexecute, SyntheticBci, SyntheticBci});
+      DeoptInputs.insert(DeoptInputs.begin(), {SyntheticShouldReexecute,
+                                               SyntheticBci, SyntheticBci});
     }
 
     OperandBundleDef NewDeopt("deopt", DeoptInputs);

--- a/llvm/lib/Transforms/Jeandle/JeandleNarrowOopMarker.cpp
+++ b/llvm/lib/Transforms/Jeandle/JeandleNarrowOopMarker.cpp
@@ -86,8 +86,14 @@ PreservedAnalyses JeandleNarrowOopMarker::run(Function &F,
       // deopt bundle, and JeandleCompiledCode::resolve_reloc_info treats
       // routine call sites as bci == -1. Remove this path once routine
       // calls carry real deopt bundles.
+      //
+      // JeandleCompiledCode::parse_stackmap always reads a leading
+      // should_reexecute flag before the duplicated-bci pair. A synthetic
+      // bundle must include it too, or the reader misinterprets this bci
+      // as should_reexecute and desyncs every value after it.
+      Value *SyntheticShouldReexecute = ConstantInt::get(Type::getInt32Ty(Ctx), 0);
       Value *SyntheticBci = ConstantInt::get(Type::getInt32Ty(Ctx), -1);
-      DeoptInputs.insert(DeoptInputs.begin(), {SyntheticBci, SyntheticBci});
+      DeoptInputs.insert(DeoptInputs.begin(), {SyntheticShouldReexecute, SyntheticBci, SyntheticBci});
     }
 
     OperandBundleDef NewDeopt("deopt", DeoptInputs);


### PR DESCRIPTION
JeandleNarrowOopMarker synthesizes a minimal deopt bundle for call sites (e.g. GC post-barrier calls) that otherwise carry no deopt info, so it can still record narrow-oop GC roots. The synthetic bundle only inserted a duplicated bci pair, but JeandleCompiledCode::parse_stackmap always reads a leading should_reexecute flag before the bci pair. The missing flag shifts every subsequent read in the record by one slot, which corrupts the following duplicated-bci comparison and trips guarantee(bci == ...) failed: duplicated bci must match.

Insert a synthetic should_reexecute flag ahead of the bci pair to match the reader's expected layout.

## Related issue(s):

issue #

## What this PR does / why we need it:
