### PR TITLE
fix: typeIntersect drops Exact on equal-klass intersection

### DIFF
--- a/llvm/lib/IR/Jeandle/JavaType.cpp
+++ b/llvm/lib/IR/Jeandle/JavaType.cpp
@@ -285,7 +285,15 @@ JavaType jeandle::typeIntersect(JavaType A, JavaType B) {
   if (A.isKnown() && B.isKnown()) {
     const VMCallbacks *CB = getVMCallbacks();
     assert(CB && CB->IsSubtype && "VMCallbacks must be set");
-    if (CB->IsSubtype(A.Klass, B.Klass)) {
+    if (A.Klass == B.Klass) {
+      // Equal klass: Exact is conjunctive. Exact=true is the stricter claim
+      // ("value is exactly this class"), so if either operand is exact the
+      // intersection is exact. IsSubtype is reflexive, so without this case
+      // the first branch below would win and silently drop the other side's
+      // Exact. (Dual of typeUnion's A.Exact && B.Exact for the equal case.)
+      Result.Klass = A.Klass;
+      Result.Exact = A.Exact || B.Exact;
+    } else if (CB->IsSubtype(A.Klass, B.Klass)) {
       Result.Klass = A.Klass;
       Result.Exact = A.Exact;
     } else if (CB->IsSubtype(B.Klass, A.Klass)) {
@@ -1007,6 +1015,11 @@ static JavaType sharpenFromDominators(Value *V, Instruction *Context,
                         << " from dominating check in " << BB->getName()
                         << "\n");
       assert(CB->IsEffectivelyFinal && "IsEffectivelyFinal must be set");
+      // Exact is a pure function of the klass (IsEffectivelyFinal), not carried
+      // in from an independent source. So when Klass == Best.Klass — the
+      // reflexive IsSubtype branch below — IsExact already equals Best.Exact and
+      // the assignment is a no-op. Contrast typeIntersect, whose operands' Exact
+      // come from different provenances and can diverge for the same klass.
       bool IsExact = CB->IsEffectivelyFinal(Klass);
       if (!Best.isKnown()) {
         Best.Klass = Klass;

--- a/llvm/lib/IR/Jeandle/JavaType.cpp
+++ b/llvm/lib/IR/Jeandle/JavaType.cpp
@@ -1017,9 +1017,10 @@ static JavaType sharpenFromDominators(Value *V, Instruction *Context,
       assert(CB->IsEffectivelyFinal && "IsEffectivelyFinal must be set");
       // Exact is a pure function of the klass (IsEffectivelyFinal), not carried
       // in from an independent source. So when Klass == Best.Klass — the
-      // reflexive IsSubtype branch below — IsExact already equals Best.Exact and
-      // the assignment is a no-op. Contrast typeIntersect, whose operands' Exact
-      // come from different provenances and can diverge for the same klass.
+      // reflexive IsSubtype branch below — IsExact already equals Best.Exact
+      // and the assignment is a no-op. Contrast typeIntersect, whose operands'
+      // Exact come from different provenances and can diverge for the same
+      // klass.
       bool IsExact = CB->IsEffectivelyFinal(Klass);
       if (!Best.isKnown()) {
         Best.Klass = Klass;

--- a/llvm/test/Jeandle/cha-devirtualization/Inputs/intersect-exact.cblog
+++ b/llvm/test/Jeandle/cha-devirtualization/Inputs/intersect-exact.cblog
@@ -1,0 +1,14 @@
+# Regression replay for intersect-exact.ll.
+#
+# Fix path: the dominating check_instanceof(500, %recv) sharpens %recv to exact
+# because klass 500 is effectively final; typeIntersect then yields {500, true}.
+IsEffectivelyFinal 500 = true
+# Bug path: the unfixed typeIntersect takes the reflexive IsSubtype(500, 500)
+# branch instead of the explicit equality check.
+IsSubtype 500 500 = true
+# Fix: Exact=true  -> CHA returns the unique target -> the invoke devirtualizes.
+GetCHAOptInfo 100 200 300 500 true 0 = "600#700#25#Optimized_target"
+# Bug: Exact=false -> CHA returns no target -> the invoke stays virtual.
+# (This entry is what makes the test fail without the typeIntersect fix.)
+GetCHAOptInfo 100 200 300 500 false 0 = ""
+UpdateToStaticOptVirtualCall 42 = true

--- a/llvm/test/Jeandle/cha-devirtualization/intersect-exact.ll
+++ b/llvm/test/Jeandle/cha-devirtualization/intersect-exact.ll
@@ -1,0 +1,53 @@
+; RUN: opt -S -passes="cha-devirtualization" -jeandle-vm-callback-log=%S/Inputs/intersect-exact.cblog %s 2>&1 | FileCheck %s
+
+; Regression test for typeIntersect dropping Exact on an equal-klass intersection.
+;
+; %recv has the base type {klass 500, Exact=false} from the "java-klass" parameter
+; attribute (no "java-klass-exact"). A dominating check_instanceof(500, %recv)
+; sharpens it to {500, Exact=true} because klass 500 is effectively final.
+; typeIntersect({500,false}, {500,true}) must yield {500,true}.
+;
+; With the bug it yields {500,false}, so CHA forwards Exact=false to GetCHAOptInfo
+; (replay returns no target) and the invoke stays virtual. With the fix, Exact=true
+; propagates and CHA devirtualizes the invoke.
+
+@jeandle.personality = global ptr null
+
+declare hotspotcc i1 @jeandle.check_instanceof(ptr, ptr addrspace(1))
+declare hotspotcc i32 @Virtual_target(ptr addrspace(1)) #1 gc "hotspotgc"
+
+define hotspotcc i32 @caller(ptr addrspace(1) "java-klass"="500" %recv) #0 gc "hotspotgc" personality ptr @jeandle.personality {
+entry:
+  %ck = call hotspotcc i1 @jeandle.check_instanceof(ptr inttoptr (i64 500 to ptr), ptr addrspace(1) %recv)
+  br i1 %ck, label %do_call, label %no_call
+
+do_call:
+  %ret = invoke hotspotcc i32 @Virtual_target(ptr addrspace(1) %recv) #2 [ "deopt"(i32 7, i32 7) ]
+          to label %normal unwind label %unwind
+
+no_call:
+  ret i32 -2
+
+normal:
+  ret i32 %ret
+
+unwind:
+  %lp = landingpad i64
+          cleanup
+  ret i32 -1
+}
+
+; Devirtualization happens only when Exact=true is propagated through typeIntersect.
+; CHECK-LABEL: define hotspotcc i32 @caller(
+; CHECK: call hotspotcc i1 @jeandle.check_instanceof(ptr inttoptr (i64 600 to ptr), ptr addrspace(1) %recv)
+; CHECK: invoke hotspotcc i32 @Optimized_target(ptr addrspace(1) %recv)
+; CHECK: "monomorphic-target"
+
+attributes #0 = { "java-method"="100" }
+attributes #1 = { "java-method"="200" }
+attributes #2 = { "bytecode"="invokevirtual" "call-site"="900" "declared-holder"="300" "statepoint-id"="42" "statepoint-num-patch-bytes"="15" }
+
+!java-method-compilation = !{}
+!static-call-patch-size = !{!0}
+
+!0 = !{i32 5}


### PR DESCRIPTION
## Problem
  jeandle::typeIntersect silently discards one operand's Exact flag when the two constraints share the same positive 

```
klass:
     
  typeIntersect({Klass: Animal, Exact: false}, {Klass: Animal, Exact: true})
    → currently: {Klass: Animal, Exact: false}   ❌
    → expected:  {Klass: Animal, Exact: true}    ✓
```

## Root cause

  typeIntersect selects the more specific positive klass using the reflexive IsSubtype query (JavaType.cpp):

```
  if (CB->IsSubtype(A.Klass, B.Klass)) {   // reflexive: TRUE when A.Klass == B.Klass
    Result.Klass = A.Klass;
    Result.Exact = A.Exact;                 // ← ignores B.Exact
  } else if (CB->IsSubtype(B.Klass, A.Klass)) {
    Result.Klass = B.Klass;
    Result.Exact = B.Exact;
  }
```

  IsSubtype is reflexive — K->is_subtype_of(K) returns true (HotSpot Klass::is_subtype_of). So when A.Klass == B.Klass, the first branch is always taken and Result.Exact copies only A.Exact;
  B.Exact is lost.

  Why ||: intersection means both constraints hold simultaneously, and Exact=true is the stricter claim ("the value is exactly this class, not a subclass"). If either operand is exact, the
  intersection is exact. This is the dual of typeUnion, which correctly uses A.Exact && B.Exact for the equal case (a union is exact only when both sources are exact).

## Impact

  A precision bug, not a miscompile — it errs toward the looser, sound type — but it causes downstream consumers to miss optimizations. CHADevirtualization forwards ReceiverType.Exact into
  GetCHAOptInfo (CHADevirtualization.cpp); a dropped Exact weakens or defeats devirtualization.

## Fix

  Handle the equal-klass case explicitly before the subtype checks (this also avoids a VM callback in the common case):

```
  if (A.isKnown() && B.isKnown()) {
    const VMCallbacks *CB = getVMCallbacks();
    assert(CB && CB->IsSubtype && "VMCallbacks must be set");
    if (A.Klass == B.Klass) {
      // Equal klass: Exact is conjunctive — the stricter (exact) claim wins.
      Result.Klass = A.Klass;
      Result.Exact = A.Exact || B.Exact;
    } else if (CB->IsSubtype(A.Klass, B.Klass)) {
      Result.Klass = A.Klass;
      Result.Exact = A.Exact;
    } else if (CB->IsSubtype(B.Klass, A.Klass)) {
      Result.Klass = B.Klass;
      Result.Exact = B.Exact;
    }
  }
```

  The strict-subtype branches are unchanged and already correct: the more-specific klass determines Exact; a supertype-side Exact=true would be contradictory/dead and is correctly ignored.