### PR TITLE
feat: Late insertion for array's GC barrier

### DIFF
--- a/llvm/lib/Transforms/Jeandle/InsertGCBarriers.cpp
+++ b/llvm/lib/Transforms/Jeandle/InsertGCBarriers.cpp
@@ -106,8 +106,8 @@ PreservedAnalyses InsertGCBarriers::run(Function &F,
         BarrierValue = PostBuilder.CreateAddrSpaceCast(StoredValue, OopTy);
       }
 
-      CallInst *PostCall =
-          PostBuilder.CreateCall(PostBarrierFunc, {DerivedPointer, BarrierValue});
+      CallInst *PostCall = PostBuilder.CreateCall(
+          PostBarrierFunc, {DerivedPointer, BarrierValue});
       PostCall->setCallingConv(CallingConv::Hotspot_JIT);
     }
     Changed = true;

--- a/llvm/lib/Transforms/Jeandle/InsertGCBarriers.cpp
+++ b/llvm/lib/Transforms/Jeandle/InsertGCBarriers.cpp
@@ -106,11 +106,8 @@ PreservedAnalyses InsertGCBarriers::run(Function &F,
         BarrierValue = PostBuilder.CreateAddrSpaceCast(StoredValue, OopTy);
       }
 
-      Value *BasePointer = PostBuilder.CreateIntrinsic(
-          Intrinsic::experimental_gc_get_pointer_base, {PointerTy, PointerTy},
-          {DerivedPointer}, {} /* FMFSource */, "base.pointer");
       CallInst *PostCall =
-          PostBuilder.CreateCall(PostBarrierFunc, {BasePointer, BarrierValue});
+          PostBuilder.CreateCall(PostBarrierFunc, {DerivedPointer, BarrierValue});
       PostCall->setCallingConv(CallingConv::Hotspot_JIT);
     }
     Changed = true;

--- a/llvm/test/Jeandle/card-table-barrier.ll
+++ b/llvm/test/Jeandle/card-table-barrier.ll
@@ -2,8 +2,7 @@
 
 ; CHECK: %derived.pointer = getelementptr inbounds i8, ptr addrspace(1) %dst, i64 24
 ; CHECK-NEXT: store atomic ptr addrspace(1) %src, ptr addrspace(1) %derived.pointer unordered, align 8
-; CHECK-NEXT: %base.pointer = call ptr addrspace(1) @llvm.experimental.gc.get.pointer.base.p1.p1(ptr addrspace(1) %derived.pointer)
-; CHECK-NEXT: %0 = ptrtoint ptr addrspace(1) %base.pointer to i64
+; CHECK-NEXT: %0 = ptrtoint ptr addrspace(1) %derived.pointer to i64
 ; CHECK-NEXT: %1 = lshr i64 %0, 9
 ; CHECK-NEXT: %2 = getelementptr inbounds i8, ptr inttoptr (i64 139709660639232 to ptr), i64 %1
 ; CHECK-NEXT: store atomic i8 0, ptr %2 unordered, align 1

--- a/llvm/test/Jeandle/g1-barrier.ll
+++ b/llvm/test/Jeandle/g1-barrier.ll
@@ -4,8 +4,7 @@
 ; CHECK-NEXT: %0 = load atomic ptr addrspace(1), ptr addrspace(1) %derived.pointer unordered, align 8
 ; CHECK-NEXT: store ptr addrspace(1) %0, ptr @satb_log
 ; CHECK-NEXT: store atomic ptr addrspace(1) %src, ptr addrspace(1) %derived.pointer unordered, align 8
-; CHECK-NEXT: %base.pointer = call ptr addrspace(1) @llvm.experimental.gc.get.pointer.base.p1.p1(ptr addrspace(1) %derived.pointer)
-; CHECK-NEXT: %1 = ptrtoint ptr addrspace(1) %base.pointer to i64
+; CHECK-NEXT: %1 = ptrtoint ptr addrspace(1) %derived.pointer to i64
 ; CHECK-NEXT: %2 = lshr i64 %1, 9
 ; CHECK-NEXT: %3 = getelementptr inbounds i8, ptr inttoptr (i64 139709660639232 to ptr), i64 %2
 ; CHECK-NEXT: store atomic i8 0, ptr %3 unordered, align 1

--- a/llvm/test/Jeandle/lately-use-cross-default-opt.ll
+++ b/llvm/test/Jeandle/lately-use-cross-default-opt.ll
@@ -4,8 +4,7 @@
 ; CHECK-USE: @llvm.used = appending global
 ; CHECK-USE: define hotspotcc void @test_gc_write_barrier
 ; CHECK-USE: store atomic ptr addrspace(1) %src, ptr addrspace(1) %derived.pointer
-; CHECK-USE-NEXT: %base.pointer = call ptr addrspace(1) @llvm.experimental.gc.get.pointer.base.p1.p1(ptr addrspace(1) %derived.pointer)
-; CHECK-USE-NEXT: call hotspotcc void @jeandle.post_barrier(ptr addrspace(1) %base.pointer, ptr addrspace(1) %src)
+; CHECK-USE-NEXT: call hotspotcc void @jeandle.post_barrier(ptr addrspace(1) %derived.pointer, ptr addrspace(1) %src)
 
 ; CHECK-ERASE-NOT: @llvm.used = appending global
 ; CHECK-ERASE-NOT: @jeandle.card_table_barrier


### PR DESCRIPTION
## Related issue(s):

issue #https://github.com/jeandle/jeandle-jdk/issues/464

## What this PR does / why we need it:

Insert array's GC post barrier in `InsertGCBarriers`