### PR TITLE
enhance: add constant folding for oop, mirror, and Klass metadata

### DIFF
--- a/llvm/include/llvm/IR/Jeandle/VMCallback.h
+++ b/llvm/include/llvm/IR/Jeandle/VMCallback.h
@@ -35,6 +35,11 @@ enum class VMCallbackValueType : uint8_t {
   String,  // std::string
 };
 
+/// GetMirrorKlass result used when the oop is not a constant Class mirror or
+/// its represented type is unavailable. Zero remains available to encode the
+/// known-null Klass field of a primitive Class mirror.
+inline constexpr uintptr_t MirrorKlassUnavailable = ~uintptr_t{0};
+
 /// Result reported for an inline attempt after LLVM starts processing it.
 /// Keep the numeric values stable because the JVM records them.
 enum class JeandleInlineReason : int {
@@ -157,6 +162,12 @@ enum class JeandleInlineReason : int {
   def(GetOopKlass, uintptr_t, Uintptr,                                           \
       (int a1), (a1),                                                            \
       (VMCallbackValueType::Int), 1)                                             \
+  def(GetMirrorKlass, uintptr_t, Uintptr,                                        \
+      (int a1), (a1),                                                            \
+      (VMCallbackValueType::Int), 1)                                             \
+  def(GetKlassLayoutHelper, int, Int,                                            \
+      (uintptr_t a1), (a1),                                                      \
+      (VMCallbackValueType::Uintptr), 1)                                         \
   def(IsOkToInline, bool, Bool,                                                  \
       (int a1, int a2, uintptr_t a3), (a1, a2, a3),                              \
       (VMCallbackValueType::Int, VMCallbackValueType::Int,                       \
@@ -237,6 +248,15 @@ enum class JeandleInlineReason : int {
 ///   GetOopKlass         — Returns the actual runtime klass pointer of the
 ///                         constant oop with the given oop id, or 0 if it is
 ///                         unavailable. Pure (id -> klass).
+///   GetMirrorKlass      — For a constant java.lang.Class mirror, returns its
+///                         represented reference Klass pointer, or 0 when the
+///                         mirror represents a primitive type. Returns
+///                         MirrorKlassUnavailable for a non-mirror or an
+///                         unavailable value. Pure (id -> represented klass).
+///   GetKlassLayoutHelper
+///                       — Returns Klass::layout_helper() for a constant Klass
+///                         pointer, or 0 if unavailable. Pure (klass ->
+///                         layout helper).
 ///   IsOkToInline        — Given an inline scope id, call-site BCI, and callee
 ///                         Java method pointer, returns whether the VM allows
 ///                         this inline attempt.

--- a/llvm/lib/Transforms/Jeandle/ConstantFieldFolding.cpp
+++ b/llvm/lib/Transforms/Jeandle/ConstantFieldFolding.cpp
@@ -38,6 +38,11 @@
 using namespace llvm;
 
 STATISTIC(NumFieldsFolded, "Number of constant field loads folded");
+STATISTIC(NumKlassesFolded, "Number of jeandle.load_klass calls folded");
+STATISTIC(NumMirrorKlassesFolded,
+          "Number of jeandle.load_mirror_klass calls folded");
+STATISTIC(NumKlassLayoutHelpersFolded,
+          "Number of jeandle.layout_helper calls folded");
 STATISTIC(NumRounds, "Number of folding rounds");
 STATISTIC(NumOopChains, "Number of oop chains followed");
 
@@ -308,6 +313,115 @@ matchFieldLoad(LoadInst *LI, const DenseMap<Value *, int> &ConstOops,
   return FieldLoadMatch{LI, ImmediateGEP, *BaseId, OffsetVal};
 }
 
+std::optional<uintptr_t> getConstantKlassPointer(Value *V) {
+  V = V->stripPointerCasts();
+  if (auto *CE = dyn_cast<ConstantExpr>(V)) {
+    if (CE->getOpcode() != Instruction::IntToPtr || CE->getNumOperands() != 1)
+      return std::nullopt;
+    if (auto *CI = dyn_cast<ConstantInt>(CE->getOperand(0)))
+      return static_cast<uintptr_t>(CI->getZExtValue());
+    return std::nullopt;
+  }
+  if (auto *CI = dyn_cast<ConstantInt>(V))
+    return static_cast<uintptr_t>(CI->getZExtValue());
+  return std::nullopt;
+}
+
+Constant *klassPointerConstant(LLVMContext &Ctx, Type *Ty, uintptr_t Klass) {
+  if (Klass == 0 || !Ty->isPointerTy())
+    return nullptr;
+  return ConstantExpr::getIntToPtr(
+      ConstantInt::get(Type::getInt64Ty(Ctx), Klass), Ty);
+}
+
+bool isLoadKlassCall(CallInst *CI) {
+  Function *Callee = CI ? CI->getCalledFunction() : nullptr;
+  return Callee && Callee->getName() == "jeandle.load_klass" &&
+         CI->arg_size() == 1;
+}
+
+bool isLoadMirrorKlassCall(CallInst *CI) {
+  Function *Callee = CI ? CI->getCalledFunction() : nullptr;
+  return Callee && Callee->getName() == "jeandle.load_mirror_klass" &&
+         CI->arg_size() == 1;
+}
+
+bool isLayoutHelperCall(CallInst *CI) {
+  Function *Callee = CI ? CI->getCalledFunction() : nullptr;
+  return Callee && Callee->getName() == "jeandle.layout_helper" &&
+         CI->arg_size() == 1;
+}
+
+bool foldLoadKlassCall(CallInst *CI, const jeandle::VMCallbacks &CB,
+                       const DenseMap<Value *, int> &ConstOops) {
+  if (!isLoadKlassCall(CI) || !CB.GetOopKlass)
+    return false;
+
+  std::optional<int> OopId =
+      lookupConstOop(CI->getArgOperand(0), ConstOops);
+  if (!OopId)
+    return false;
+
+  uintptr_t Klass = CB.GetOopKlass(*OopId);
+  Constant *KlassConstant =
+      klassPointerConstant(CI->getContext(), CI->getType(), Klass);
+  if (!KlassConstant)
+    return false;
+
+  CI->replaceAllUsesWith(KlassConstant);
+  CI->eraseFromParent();
+  return true;
+}
+
+bool foldLoadMirrorKlassCall(CallInst *CI, const jeandle::VMCallbacks &CB,
+                             const DenseMap<Value *, int> &ConstOops) {
+  if (!isLoadMirrorKlassCall(CI) || !CI->getType()->isPointerTy() ||
+      !CB.GetMirrorKlass)
+    return false;
+
+  std::optional<int> OopId =
+      lookupConstOop(CI->getArgOperand(0), ConstOops);
+  if (!OopId)
+    return false;
+
+  uintptr_t Klass = CB.GetMirrorKlass(*OopId);
+  if (Klass == jeandle::MirrorKlassUnavailable)
+    return false;
+
+  Constant *KlassConstant;
+  if (Klass == 0)
+    KlassConstant =
+        ConstantPointerNull::get(cast<PointerType>(CI->getType()));
+  else
+    KlassConstant =
+        klassPointerConstant(CI->getContext(), CI->getType(), Klass);
+  if (!KlassConstant)
+    return false;
+
+  CI->replaceAllUsesWith(KlassConstant);
+  CI->eraseFromParent();
+  return true;
+}
+
+bool foldLayoutHelperCall(CallInst *CI, const jeandle::VMCallbacks &CB) {
+  if (!isLayoutHelperCall(CI) || !CI->getType()->isIntegerTy(32) ||
+      !CB.GetKlassLayoutHelper)
+    return false;
+
+  std::optional<uintptr_t> Klass =
+      getConstantKlassPointer(CI->getArgOperand(0));
+  if (!Klass || *Klass == 0)
+    return false;
+
+  int LayoutHelper = CB.GetKlassLayoutHelper(*Klass);
+  if (LayoutHelper == 0)
+    return false;
+
+  CI->replaceAllUsesWith(ConstantInt::get(CI->getType(), LayoutHelper));
+  CI->eraseFromParent();
+  return true;
+}
+
 bool isSubIntBasicType(int BasicType) {
   return BasicType == T_BOOLEAN || BasicType == T_BYTE || BasicType == T_CHAR ||
          BasicType == T_SHORT;
@@ -536,15 +650,61 @@ PreservedAnalyses ConstantFieldFolding::run(Function &F,
     DenseMap<Value *, int> ConstOops = computeConstOops(F);
     ReversePostOrderTraversal<Function *> RPOT(&F);
 
+    SmallVector<CallInst *, 16> LoadKlassCalls;
+    SmallVector<CallInst *, 16> LoadMirrorKlassCalls;
+    SmallVector<CallInst *, 16> LayoutHelperCalls;
     SmallVector<LoadInst *, 16> Loads;
     for (BasicBlock *BB : RPOT) {
       for (Instruction &I : *BB) {
+        if (auto *CI = dyn_cast<CallInst>(&I)) {
+          if (isLoadKlassCall(CI))
+            LoadKlassCalls.push_back(CI);
+          if (isLoadMirrorKlassCall(CI))
+            LoadMirrorKlassCalls.push_back(CI);
+          if (isLayoutHelperCall(CI))
+            LayoutHelperCalls.push_back(CI);
+        }
         if (auto *LI = dyn_cast<LoadInst>(&I))
           Loads.push_back(LI);
       }
     }
 
+    // Fold object Klass loads before layout-helper queries so that a complete
+    // constant-oop -> Klass* -> layout-helper chain collapses in one round.
+    for (CallInst *CI : LoadKlassCalls) {
+      if (CI->getParent() == nullptr)
+        continue;
+      if (foldLoadKlassCall(CI, *CB, ConstOops)) {
+        ++NumKlassesFolded;
+        RoundChanged = true;
+        Changed = true;
+      }
+    }
+
+    for (CallInst *CI : LoadMirrorKlassCalls) {
+      if (CI->getParent() == nullptr)
+        continue;
+      if (foldLoadMirrorKlassCall(CI, *CB, ConstOops)) {
+        ++NumMirrorKlassesFolded;
+        RoundChanged = true;
+        Changed = true;
+      }
+    }
+
+    for (CallInst *CI : LayoutHelperCalls) {
+      if (CI->getParent() == nullptr)
+        continue;
+      if (foldLayoutHelperCall(CI, *CB)) {
+        ++NumKlassLayoutHelpersFolded;
+        RoundChanged = true;
+        Changed = true;
+      }
+    }
+
     for (LoadInst *LI : Loads) {
+      if (LI->getParent() == nullptr)
+        continue;
+
       std::optional<FieldLoadMatch> Match = matchFieldLoad(LI, ConstOops, DL);
       if (!Match)
         continue;

--- a/llvm/test/Jeandle/constant-field-folding/Inputs/klass-layout-chain.cblog
+++ b/llvm/test/Jeandle/constant-field-folding/Inputs/klass-layout-chain.cblog
@@ -1,0 +1,2 @@
+GetOopKlass 0 = 123456
+GetKlassLayoutHelper 123456 = -2147483637

--- a/llvm/test/Jeandle/constant-field-folding/Inputs/layout-helper-call.cblog
+++ b/llvm/test/Jeandle/constant-field-folding/Inputs/layout-helper-call.cblog
@@ -1,0 +1,2 @@
+GetKlassLayoutHelper 123456 = -2147483637
+GetKlassLayoutHelper 654321 = 0

--- a/llvm/test/Jeandle/constant-field-folding/Inputs/load-klass.cblog
+++ b/llvm/test/Jeandle/constant-field-folding/Inputs/load-klass.cblog
@@ -1,0 +1,2 @@
+GetOopKlass 0 = 123456
+GetOopKlass 1 = 0

--- a/llvm/test/Jeandle/constant-field-folding/Inputs/load-mirror-klass.cblog
+++ b/llvm/test/Jeandle/constant-field-folding/Inputs/load-mirror-klass.cblog
@@ -1,0 +1,3 @@
+GetMirrorKlass 0 = 234567
+GetMirrorKlass 1 = 0
+GetMirrorKlass 2 = 18446744073709551615

--- a/llvm/test/Jeandle/constant-field-folding/Inputs/mirror-klass-layout-chain.cblog
+++ b/llvm/test/Jeandle/constant-field-folding/Inputs/mirror-klass-layout-chain.cblog
@@ -1,0 +1,5 @@
+GetConstantFieldInfo 0 16 = 12
+GetConstantFieldValue 0 16 = 1
+GetOopHandleName 1 = "oop_handle_ClassMirror_1"
+GetMirrorKlass 1 = 234567
+GetKlassLayoutHelper 234567 = -2147483637

--- a/llvm/test/Jeandle/constant-field-folding/klass-layout-chain.ll
+++ b/llvm/test/Jeandle/constant-field-folding/klass-layout-chain.ll
@@ -1,0 +1,23 @@
+; RUN: opt -S -passes="constant-field-folding" -jeandle-vm-callback-log=%S/Inputs/klass-layout-chain.cblog %s 2>&1 | FileCheck %s
+
+@oop_handle_Test_0 = external dso_local global ptr addrspace(1)
+
+declare hotspotcc ptr @jeandle.load_klass(ptr addrspace(1))
+declare hotspotcc i32 @jeandle.layout_helper(ptr)
+
+define hotspotcc i32 @fold_klass_layout_chain() #0 gc "hotspotgc" {
+entry:
+  %obj = load ptr addrspace(1), ptr @oop_handle_Test_0
+  %klass = call hotspotcc ptr @jeandle.load_klass(ptr addrspace(1) %obj)
+  %layout = call hotspotcc i32 @jeandle.layout_helper(ptr %klass)
+  ret i32 %layout
+}
+
+; CHECK-LABEL: define hotspotcc i32 @fold_klass_layout_chain()
+; CHECK:       entry:
+; CHECK-NEXT:    %obj = load ptr addrspace(1), ptr @oop_handle_Test_0
+; CHECK-NEXT:    ret i32 -2147483637
+
+attributes #0 = { "java-method"="1" }
+
+!java-method-compilation = !{}

--- a/llvm/test/Jeandle/constant-field-folding/layout-helper-call.ll
+++ b/llvm/test/Jeandle/constant-field-folding/layout-helper-call.ll
@@ -1,0 +1,47 @@
+; RUN: opt -S -passes="constant-field-folding" -jeandle-vm-callback-log=%S/Inputs/layout-helper-call.cblog %s 2>&1 | FileCheck %s
+
+declare hotspotcc i32 @jeandle.layout_helper(ptr)
+
+define hotspotcc i32 @fold_layout_helper() #0 gc "hotspotgc" {
+entry:
+  %layout = call hotspotcc i32 @jeandle.layout_helper(ptr inttoptr (i64 123456 to ptr))
+  ret i32 %layout
+}
+
+; CHECK-LABEL: define hotspotcc i32 @fold_layout_helper()
+; CHECK:       entry:
+; CHECK-NEXT:    ret i32 -2147483637
+
+define hotspotcc i32 @keep_dynamic(ptr %klass) #0 gc "hotspotgc" {
+entry:
+  %layout = call hotspotcc i32 @jeandle.layout_helper(ptr %klass)
+  ret i32 %layout
+}
+
+; CHECK-LABEL: define hotspotcc i32 @keep_dynamic(
+; CHECK:         %layout = call hotspotcc i32 @jeandle.layout_helper(ptr %klass)
+; CHECK-NEXT:    ret i32 %layout
+
+define hotspotcc i32 @keep_null() #0 gc "hotspotgc" {
+entry:
+  %layout = call hotspotcc i32 @jeandle.layout_helper(ptr null)
+  ret i32 %layout
+}
+
+; CHECK-LABEL: define hotspotcc i32 @keep_null()
+; CHECK:         %layout = call hotspotcc i32 @jeandle.layout_helper(ptr null)
+; CHECK-NEXT:    ret i32 %layout
+
+define hotspotcc i32 @keep_unavailable() #0 gc "hotspotgc" {
+entry:
+  %layout = call hotspotcc i32 @jeandle.layout_helper(ptr inttoptr (i64 654321 to ptr))
+  ret i32 %layout
+}
+
+; CHECK-LABEL: define hotspotcc i32 @keep_unavailable()
+; CHECK:         %layout = call hotspotcc i32 @jeandle.layout_helper(ptr inttoptr (i64 654321 to ptr))
+; CHECK-NEXT:    ret i32 %layout
+
+attributes #0 = { "java-method"="1" }
+
+!java-method-compilation = !{}

--- a/llvm/test/Jeandle/constant-field-folding/load-klass.ll
+++ b/llvm/test/Jeandle/constant-field-folding/load-klass.ll
@@ -1,0 +1,65 @@
+; RUN: opt -S -passes="constant-field-folding" -jeandle-vm-callback-log=%S/Inputs/load-klass.cblog %s 2>&1 | FileCheck %s
+
+@oop_handle_Test_0 = external dso_local global ptr addrspace(1)
+@oop_handle_Test_1 = external dso_local global ptr addrspace(1)
+
+declare hotspotcc ptr @jeandle.load_klass(ptr addrspace(1))
+
+define hotspotcc ptr @fold_direct() #0 gc "hotspotgc" {
+entry:
+  %obj = load ptr addrspace(1), ptr @oop_handle_Test_0
+  %klass = call hotspotcc ptr @jeandle.load_klass(ptr addrspace(1) %obj)
+  ret ptr %klass
+}
+
+; CHECK-LABEL: define hotspotcc ptr @fold_direct()
+; CHECK:       entry:
+; CHECK-NEXT:    %obj = load ptr addrspace(1), ptr @oop_handle_Test_0
+; CHECK-NEXT:    ret ptr inttoptr (i64 123456 to ptr)
+
+define hotspotcc ptr @fold_same_phi(i1 %cond) #0 gc "hotspotgc" {
+entry:
+  %obj = load ptr addrspace(1), ptr @oop_handle_Test_0
+  br i1 %cond, label %left, label %right
+
+left:
+  br label %merge
+
+right:
+  br label %merge
+
+merge:
+  %merged = phi ptr addrspace(1) [ %obj, %left ], [ %obj, %right ]
+  %klass = call hotspotcc ptr @jeandle.load_klass(ptr addrspace(1) %merged)
+  ret ptr %klass
+}
+
+; CHECK-LABEL: define hotspotcc ptr @fold_same_phi(
+; CHECK:       merge:
+; CHECK-NEXT:    %merged = phi ptr addrspace(1)
+; CHECK-NEXT:    ret ptr inttoptr (i64 123456 to ptr)
+
+define hotspotcc ptr @keep_dynamic(ptr addrspace(1) %obj) #0 gc "hotspotgc" {
+entry:
+  %klass = call hotspotcc ptr @jeandle.load_klass(ptr addrspace(1) %obj)
+  ret ptr %klass
+}
+
+; CHECK-LABEL: define hotspotcc ptr @keep_dynamic(
+; CHECK:         %klass = call hotspotcc ptr @jeandle.load_klass(ptr addrspace(1) %obj)
+; CHECK-NEXT:    ret ptr %klass
+
+define hotspotcc ptr @keep_unavailable() #0 gc "hotspotgc" {
+entry:
+  %obj = load ptr addrspace(1), ptr @oop_handle_Test_1
+  %klass = call hotspotcc ptr @jeandle.load_klass(ptr addrspace(1) %obj)
+  ret ptr %klass
+}
+
+; CHECK-LABEL: define hotspotcc ptr @keep_unavailable()
+; CHECK:         %klass = call hotspotcc ptr @jeandle.load_klass(ptr addrspace(1) %obj)
+; CHECK-NEXT:    ret ptr %klass
+
+attributes #0 = { "java-method"="1" }
+
+!java-method-compilation = !{}

--- a/llvm/test/Jeandle/constant-field-folding/load-mirror-klass.ll
+++ b/llvm/test/Jeandle/constant-field-folding/load-mirror-klass.ll
@@ -1,0 +1,56 @@
+; RUN: opt -S -passes="constant-field-folding" -jeandle-vm-callback-log=%S/Inputs/load-mirror-klass.cblog %s 2>&1 | FileCheck %s
+
+@oop_handle_ClassMirror_0 = external dso_local global ptr addrspace(1)
+@oop_handle_PrimitiveMirror_1 = external dso_local global ptr addrspace(1)
+@oop_handle_Unknown_2 = external dso_local global ptr addrspace(1)
+
+declare hotspotcc ptr @jeandle.load_mirror_klass(ptr addrspace(1))
+
+define hotspotcc ptr @fold_reference_mirror() #0 gc "hotspotgc" {
+entry:
+  %mirror = load ptr addrspace(1), ptr @oop_handle_ClassMirror_0
+  %klass = call hotspotcc ptr @jeandle.load_mirror_klass(ptr addrspace(1) %mirror)
+  ret ptr %klass
+}
+
+; CHECK-LABEL: define hotspotcc ptr @fold_reference_mirror()
+; CHECK:       entry:
+; CHECK-NEXT:    %mirror = load ptr addrspace(1), ptr @oop_handle_ClassMirror_0
+; CHECK-NEXT:    ret ptr inttoptr (i64 234567 to ptr)
+
+define hotspotcc ptr @keep_dynamic(ptr addrspace(1) %mirror) #0 gc "hotspotgc" {
+entry:
+  %klass = call hotspotcc ptr @jeandle.load_mirror_klass(ptr addrspace(1) %mirror)
+  ret ptr %klass
+}
+
+; CHECK-LABEL: define hotspotcc ptr @keep_dynamic(
+; CHECK:         %klass = call hotspotcc ptr @jeandle.load_mirror_klass(ptr addrspace(1) %mirror)
+; CHECK-NEXT:    ret ptr %klass
+
+define hotspotcc ptr @fold_primitive_mirror_to_null() #0 gc "hotspotgc" {
+entry:
+  %mirror = load ptr addrspace(1), ptr @oop_handle_PrimitiveMirror_1
+  %klass = call hotspotcc ptr @jeandle.load_mirror_klass(ptr addrspace(1) %mirror)
+  ret ptr %klass
+}
+
+; CHECK-LABEL: define hotspotcc ptr @fold_primitive_mirror_to_null()
+; CHECK:       entry:
+; CHECK-NEXT:    %mirror = load ptr addrspace(1), ptr @oop_handle_PrimitiveMirror_1
+; CHECK-NEXT:    ret ptr null
+
+define hotspotcc ptr @keep_non_mirror_or_unavailable() #0 gc "hotspotgc" {
+entry:
+  %mirror = load ptr addrspace(1), ptr @oop_handle_Unknown_2
+  %klass = call hotspotcc ptr @jeandle.load_mirror_klass(ptr addrspace(1) %mirror)
+  ret ptr %klass
+}
+
+; CHECK-LABEL: define hotspotcc ptr @keep_non_mirror_or_unavailable()
+; CHECK:         %klass = call hotspotcc ptr @jeandle.load_mirror_klass(ptr addrspace(1) %mirror)
+; CHECK-NEXT:    ret ptr %klass
+
+attributes #0 = { "java-method"="1" }
+
+!java-method-compilation = !{}

--- a/llvm/test/Jeandle/constant-field-folding/mirror-klass-layout-chain.ll
+++ b/llvm/test/Jeandle/constant-field-folding/mirror-klass-layout-chain.ll
@@ -1,0 +1,25 @@
+; RUN: opt -S -passes="constant-field-folding" -jeandle-vm-callback-log=%S/Inputs/mirror-klass-layout-chain.cblog %s 2>&1 | FileCheck %s
+
+@oop_handle_CallSite_0 = external dso_local global ptr addrspace(1)
+
+declare hotspotcc ptr @jeandle.load_mirror_klass(ptr addrspace(1))
+declare hotspotcc i32 @jeandle.layout_helper(ptr)
+
+define hotspotcc i32 @fold_constant_field_mirror_layout_chain() #0 gc "hotspotgc" {
+entry:
+  %callsite = load ptr addrspace(1), ptr @oop_handle_CallSite_0
+  %mirror.addr = getelementptr i8, ptr addrspace(1) %callsite, i64 16
+  %mirror = load ptr addrspace(1), ptr addrspace(1) %mirror.addr
+  %klass = call hotspotcc ptr @jeandle.load_mirror_klass(ptr addrspace(1) %mirror)
+  %layout = call hotspotcc i32 @jeandle.layout_helper(ptr %klass)
+  ret i32 %layout
+}
+
+; CHECK:       @oop_handle_ClassMirror_1 = external dso_local global ptr addrspace(1)
+; CHECK-LABEL: define hotspotcc i32 @fold_constant_field_mirror_layout_chain()
+; CHECK:         %folded.oop = load ptr addrspace(1), ptr @oop_handle_ClassMirror_1
+; CHECK-NEXT:    ret i32 -2147483637
+
+attributes #0 = { "java-method"="1" }
+
+!java-method-compilation = !{}


### PR DESCRIPTION
## Related issue(s):

issue https://github.com/jeandle/jeandle-jdk/issues/574

## What this PR does / why we need it:
Enhances LLVM constant field folding to resolve:

  - Constant oop to Klass
  - Constant Class mirror to Klass
  - Constant Klass to layout_helper

  This enables further constant propagation and downstream optimizations that depend on precise HotSpot type metadata.