### PR TITLE
enhance: add constant folding for oop, mirror, and Klass metadata

### DIFF
--- a/llvm/include/llvm/IR/Jeandle/VMCallback.h
+++ b/llvm/include/llvm/IR/Jeandle/VMCallback.h
@@ -35,6 +35,11 @@ enum class VMCallbackValueType : uint8_t {
   String,  // std::string
 };
 
+/// GetMirrorKlass result used when the oop is not a constant Class mirror or
+/// its represented type is unavailable. Zero remains available to encode the
+/// known-null Klass field of a primitive Class mirror.
+inline constexpr uintptr_t MirrorKlassUnavailable = ~uintptr_t{0};
+
 /// Result reported for an inline attempt after LLVM starts processing it.
 /// Keep the numeric values stable because the JVM records them.
 enum class JeandleInlineReason : int {
@@ -157,6 +162,12 @@ enum class JeandleInlineReason : int {
   def(GetOopKlass, uintptr_t, Uintptr,                                           \
       (int a1), (a1),                                                            \
       (VMCallbackValueType::Int), 1)                                             \
+  def(GetMirrorKlass, uintptr_t, Uintptr,                                        \
+      (int a1), (a1),                                                            \
+      (VMCallbackValueType::Int), 1)                                             \
+  def(GetKlassLayoutHelper, int, Int,                                            \
+      (uintptr_t a1), (a1),                                                      \
+      (VMCallbackValueType::Uintptr), 1)                                         \
   def(IsOkToInline, bool, Bool,                                                  \
       (int a1, int a2, uintptr_t a3), (a1, a2, a3),                              \
       (VMCallbackValueType::Int, VMCallbackValueType::Int,                       \
@@ -237,6 +248,15 @@ enum class JeandleInlineReason : int {
 ///   GetOopKlass         — Returns the actual runtime klass pointer of the
 ///                         constant oop with the given oop id, or 0 if it is
 ///                         unavailable. Pure (id -> klass).
+///   GetMirrorKlass      — For a constant java.lang.Class mirror, returns its
+///                         represented reference Klass pointer, or 0 when the
+///                         mirror represents a primitive type. Returns
+///                         MirrorKlassUnavailable for a non-mirror or an
+///                         unavailable value. Pure (id -> represented klass).
+///   GetKlassLayoutHelper
+///                       — Returns Klass::layout_helper() for a constant Klass
+///                         pointer, or 0 if unavailable. Pure (klass ->
+///                         layout helper).
 ///   IsOkToInline        — Given an inline scope id, call-site BCI, and callee
 ///                         Java method pointer, returns whether the VM allows
 ///                         this inline attempt.

--- a/llvm/include/llvm/IR/Jeandle/VMCallback.h
+++ b/llvm/include/llvm/IR/Jeandle/VMCallback.h
@@ -47,6 +47,11 @@ using ConstantFieldResult = std::tuple<int, int64_t>;
 /// and target method name returned by CHA devirtualization.
 using CHAOptResult = std::tuple<uintptr_t, uintptr_t, uintptr_t, std::string>;
 
+/// GetMirrorKlass result used when the oop is not a constant Class mirror or
+/// its represented type is unavailable. Zero remains available to encode the
+/// known-null Klass field of a primitive Class mirror.
+inline constexpr uintptr_t MirrorKlassUnavailable = ~uintptr_t{0};
+
 /// Result reported for an inline attempt after LLVM starts processing it.
 /// Keep the numeric values stable because the JVM records them.
 enum class JeandleInlineReason : int {
@@ -188,9 +193,18 @@ enum class JeandleInlineReason : int {
   def(GetOopKlass, uintptr_t, Uintptr,                                           \
       (int a1), (a1),                                                            \
       (VMCallbackValueType::Int), 1)                                             \
-  def(GetJavaMirror, int, Int,                                               \
-      (uintptr_t a1), (a1),                                                  \
-      (VMCallbackValueType::Uintptr), 1)                                     \
+  def(GetJavaMirror, int, Int,                                                   \
+      (uintptr_t a1), (a1),                                                      \
+      (VMCallbackValueType::Uintptr), 1)                                         \
+  def(GetMirrorKlass, uintptr_t, Uintptr,                                        \
+      (int a1), (a1),                                                            \
+      (VMCallbackValueType::Int), 1)                                             \
+  def(GetKlassLayoutHelper, int, Int,                                            \
+      (uintptr_t a1), (a1),                                                      \
+      (VMCallbackValueType::Uintptr), 1)                                         \
+  def(IsKlassInitialized, bool, Bool,                                            \
+      (uintptr_t a1), (a1),                                                      \
+      (VMCallbackValueType::Uintptr), 1)                                         \
   def(IsOkToInline, bool, Bool,                                                  \
       (int a1, int a2, uintptr_t a3), (a1, a2, a3),                              \
       (VMCallbackValueType::Int, VMCallbackValueType::Int,                       \
@@ -353,6 +367,19 @@ enum class JeandleInlineReason : int {
 ///                         jeandle.get_class on a virtual receiver (whose exact
 ///                         klass is statically known) to the constant Class
 ///                         mirror. Pure (Klass -> mirror oop id).
+///   GetMirrorKlass      — For a constant java.lang.Class mirror, returns its
+///                         represented reference Klass pointer, or 0 when the
+///                         mirror represents a primitive type. Returns
+///                         MirrorKlassUnavailable for a non-mirror or an
+///                         unavailable value. Pure (id -> represented klass).
+///   GetKlassLayoutHelper
+///                       — Returns Klass::layout_helper() for a constant Klass
+///                         pointer, or 0 if unavailable. Pure (klass ->
+///                         layout helper).
+///   IsKlassInitialized  — Returns true iff a constant Klass is an initialized
+///                         instance klass. ConstantFieldFolding only acts on a
+///                         true result because initialization is monotonic;
+///                         false retains the dynamic initialization check.
 ///   IsOkToInline        — Given an inline scope id, call-site BCI, and callee
 ///                         Java method pointer, returns whether the VM allows
 ///                         this inline attempt.
@@ -377,9 +404,6 @@ enum class JeandleInlineReason : int {
 ///                         failures before returning, so LLVM expects a true
 ///                         result.
 ///                         "oop_handle_Test_1") for a given oop id.
-///   GetOopKlass         — Returns the actual runtime klass pointer of the
-///                         constant oop with the given oop id, or 0 if it is
-///                         unavailable. Pure (id -> klass).
 ///   GetCHAOptInfo       — Returns (constraint or holder, target method,
 ///                         packed deoptimization or target info, target method
 ///                         name) for CHA devirtualization. A zero first field

--- a/llvm/include/llvm/IR/Jeandle/VMCallback.h
+++ b/llvm/include/llvm/IR/Jeandle/VMCallback.h
@@ -193,6 +193,9 @@ enum class JeandleInlineReason : int {
   def(GetOopKlass, uintptr_t, Uintptr,                                           \
       (int a1), (a1),                                                            \
       (VMCallbackValueType::Int), 1)                                             \
+  def(GetKlassConstant, uintptr_t, Uintptr,                                      \
+      (uintptr_t a1), (a1),                                                      \
+      (VMCallbackValueType::Uintptr), 1)                                         \
   def(GetJavaMirror, int, Int,                                                   \
       (uintptr_t a1), (a1),                                                      \
       (VMCallbackValueType::Uintptr), 1)                                         \
@@ -361,6 +364,9 @@ enum class JeandleInlineReason : int {
 ///   GetOopKlass         — Returns the actual runtime klass pointer of the
 ///                         constant oop with the given oop id, or 0 if it is
 ///                         unavailable. Pure (id -> klass).
+///   GetKlassConstant    — Returns a stable compile-time Klass pointer constant
+///                         for a known Klass, or 0 if unavailable. The VM
+///                         records the Klass dependency before returning it.
 ///   GetJavaMirror       — Given a VM Klass pointer, returns the oop id of its
 ///                         Java mirror (the java.lang.Class object), or -1 if
 ///                         unavailable. Used by PEA's foldGetClass to fold

--- a/llvm/lib/Analysis/Jeandle/PartialEscapeAnalysis.cpp
+++ b/llvm/lib/Analysis/Jeandle/PartialEscapeAnalysis.cpp
@@ -5318,6 +5318,19 @@ void Analyzer::processAllocation(CallBase *CB) {
   const bool IsArray = jeandle::pea::isJeandleNewArray(CB);
   assert((IsInstance ^ IsArray) &&
          "allocation must be either instance or array");
+  (void)IsArray;
+
+  // TODO(pea-new-instance-protocol): migrate all legacy lit IR and callers to
+  // the production three-argument protocol, then require arg_size() == 3 and
+  // remove this two-argument compatibility path.
+  if (IsInstance && CB->arg_size() != 2) {
+    if (CB->arg_size() != 3)
+      return;
+    auto *InitialSlowTest = dyn_cast<ConstantInt>(CB->getArgOperand(2));
+    if (!InitialSlowTest || !InitialSlowTest->getType()->isIntegerTy(1) ||
+        !InitialSlowTest->isZero())
+      return;
+  }
 
   // Refuse to virtualize identity-sensitive allocations.
   // HasFinalizer: classes that override finalize() require HotSpot's

--- a/llvm/lib/Transforms/Jeandle/ConstantFieldFolding.cpp
+++ b/llvm/lib/Transforms/Jeandle/ConstantFieldFolding.cpp
@@ -314,20 +314,6 @@ matchFieldLoad(LoadInst *LI, const DenseMap<Value *, int> &ConstOops,
   return FieldLoadMatch{LI, ImmediateGEP, *BaseId, OffsetVal};
 }
 
-std::optional<uintptr_t> getConstantKlassPointer(Value *V) {
-  V = V->stripPointerCasts();
-  if (auto *CE = dyn_cast<ConstantExpr>(V)) {
-    if (CE->getOpcode() != Instruction::IntToPtr || CE->getNumOperands() != 1)
-      return std::nullopt;
-    if (auto *CI = dyn_cast<ConstantInt>(CE->getOperand(0)))
-      return static_cast<uintptr_t>(CI->getZExtValue());
-    return std::nullopt;
-  }
-  if (auto *CI = dyn_cast<ConstantInt>(V))
-    return static_cast<uintptr_t>(CI->getZExtValue());
-  return std::nullopt;
-}
-
 Constant *klassPointerConstant(LLVMContext &Ctx, Type *Ty, uintptr_t Klass) {
   if (Klass == 0 || !Ty->isPointerTy())
     return nullptr;
@@ -366,23 +352,32 @@ bool isGetClassCall(CallInst *CI) {
 }
 
 bool foldGetClassCall(CallInst *CI, const jeandle::VMCallbacks &CB,
+                      const DenseMap<Value *, int> &ConstOops,
                       DominatorTree &DT, const DataLayout &DL) {
   if (!isGetClassCall(CI) || !isJavaOopType(CI->getType()) || !CB.GetJavaMirror)
     return false;
 
-  // The frontend emits a null check before Object.getClass. Require LLVM to
-  // prove that the receiver is non-null at this call site as well, so this
-  // fold cannot accidentally remove the Java-required NullPointerException.
-  SimplifyQuery SQ(DL, &DT, nullptr, CI);
-  if (!isKnownNonZero(CI->getArgOperand(0), SQ))
-    return false;
+  Value *Receiver = CI->getArgOperand(0);
+  int MirrorOopId = -1;
+  if (std::optional<int> OopId = lookupConstOop(Receiver, ConstOops)) {
+    // Constant oop path: derive the actual dynamic Klass from object identity.
+    if (!CB.GetOopKlass)
+      return false;
+    uintptr_t Klass = CB.GetOopKlass(*OopId);
+    if (Klass == 0)
+      return false;
+    MirrorOopId = CB.GetJavaMirror(Klass);
+  } else {
+    // Java type path: require exact type and non-null proof to preserve NPE.
+    SimplifyQuery SQ(DL, &DT, nullptr, CI);
+    if (!isKnownNonZero(Receiver, SQ))
+      return false;
 
-  jeandle::JavaType ReceiverType =
-      jeandle::getJavaType(CI->getArgOperand(0), &DT, CI);
-  if (!ReceiverType.isKnown() || !ReceiverType.Exact)
-    return false;
-
-  int MirrorOopId = CB.GetJavaMirror(ReceiverType.Klass);
+    jeandle::JavaType ReceiverType = jeandle::getJavaType(Receiver, &DT, CI);
+    if (!ReceiverType.isKnown() || !ReceiverType.Exact)
+      return false;
+    MirrorOopId = CB.GetJavaMirror(ReceiverType.Klass);
+  }
   if (MirrorOopId < 0)
     return false;
 
@@ -464,12 +459,11 @@ bool foldLayoutHelperCall(CallInst *CI, const jeandle::VMCallbacks &CB) {
       !CB.GetKlassLayoutHelper)
     return false;
 
-  std::optional<uintptr_t> Klass =
-      getConstantKlassPointer(CI->getArgOperand(0));
-  if (!Klass || *Klass == 0)
+  uintptr_t Klass = jeandle::extractKlassConstant(CI->getArgOperand(0));
+  if (Klass == 0)
     return false;
 
-  int LayoutHelper = CB.GetKlassLayoutHelper(*Klass);
+  int LayoutHelper = CB.GetKlassLayoutHelper(Klass);
   if (LayoutHelper == 0)
     return false;
 
@@ -483,16 +477,15 @@ bool foldKlassInitializedCall(CallInst *CI, const jeandle::VMCallbacks &CB) {
       !CB.IsKlassInitialized)
     return false;
 
-  std::optional<uintptr_t> Klass =
-      getConstantKlassPointer(CI->getArgOperand(0));
-  if (!Klass || *Klass == 0)
+  uintptr_t Klass = jeandle::extractKlassConstant(CI->getArgOperand(0));
+  if (Klass == 0)
     return false;
 
   // Initialization is monotonic. A class known to be fully initialized at
   // compile time stays initialized, so replacing the query with true is safe.
   // A false result is only a snapshot: the class may initialize before this
   // code executes, so retain the JavaOp and its dynamic load.
-  if (!CB.IsKlassInitialized(*Klass))
+  if (!CB.IsKlassInitialized(Klass))
     return false;
 
   CI->replaceAllUsesWith(ConstantInt::getTrue(CI->getContext()));
@@ -765,7 +758,7 @@ PreservedAnalyses ConstantFieldFolding::run(Function &F,
     for (CallInst *CI : GetClassCalls) {
       if (CI->getParent() == nullptr)
         continue;
-      if (foldGetClassCall(CI, *CB, DT, DL)) {
+      if (foldGetClassCall(CI, *CB, ConstOops, DT, DL)) {
         ++NumGetClassesFolded;
         RoundChanged = true;
         Changed = true;

--- a/llvm/lib/Transforms/Jeandle/ConstantFieldFolding.cpp
+++ b/llvm/lib/Transforms/Jeandle/ConstantFieldFolding.cpp
@@ -397,15 +397,30 @@ bool foldGetClassCall(CallInst *CI, const jeandle::VMCallbacks &CB,
 }
 
 bool foldLoadKlassCall(CallInst *CI, const jeandle::VMCallbacks &CB,
-                       const DenseMap<Value *, int> &ConstOops) {
-  if (!isLoadKlassCall(CI) || !CB.GetOopKlass)
+                       const DenseMap<Value *, int> &ConstOops,
+                       DominatorTree &DT, const DataLayout &DL) {
+  if (!isLoadKlassCall(CI))
     return false;
 
-  std::optional<int> OopId = lookupConstOop(CI->getArgOperand(0), ConstOops);
-  if (!OopId)
-    return false;
-
-  uintptr_t Klass = CB.GetOopKlass(*OopId);
+  Value *Receiver = CI->getArgOperand(0);
+  uintptr_t Klass = 0;
+  if (std::optional<int> OopId = lookupConstOop(Receiver, ConstOops)) {
+    // Constant oop path: derive the object's exact dynamic Klass.
+    if (!CB.GetOopKlass)
+      return false;
+    Klass = CB.GetOopKlass(*OopId);
+  } else {
+    // Exact Java type path: use the statically known receiver Klass.
+    SimplifyQuery SQ(DL, &DT, nullptr, CI);
+    if (!isKnownNonZero(Receiver, SQ))
+      return false;
+    jeandle::JavaType ReceiverType = jeandle::getJavaType(Receiver, &DT, CI);
+    if (!ReceiverType.isKnown() || !ReceiverType.Exact)
+      return false;
+    if (!CB.GetKlassConstant)
+      return false;
+    Klass = CB.GetKlassConstant(ReceiverType.Klass);
+  }
   Constant *KlassConstant =
       klassPointerConstant(CI->getContext(), CI->getType(), Klass);
   if (!KlassConstant)
@@ -730,7 +745,7 @@ PreservedAnalyses ConstantFieldFolding::run(Function &F,
     for (CallInst *CI : LoadKlassCalls) {
       if (CI->getParent() == nullptr)
         continue;
-      if (foldLoadKlassCall(CI, *CB, ConstOops)) {
+      if (foldLoadKlassCall(CI, *CB, ConstOops, DT, DL)) {
         ++NumKlassesFolded;
         RoundChanged = true;
         Changed = true;

--- a/llvm/lib/Transforms/Jeandle/ConstantFieldFolding.cpp
+++ b/llvm/lib/Transforms/Jeandle/ConstantFieldFolding.cpp
@@ -15,13 +15,17 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Statistic.h"
+#include "llvm/Analysis/SimplifyQuery.h"
+#include "llvm/Analysis/ValueTracking.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
+#include "llvm/IR/Dominators.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/Jeandle/JavaType.h"
 #include "llvm/IR/Jeandle/JeandleUtils.h"
 #include "llvm/IR/Jeandle/Metadata.h"
 #include "llvm/IR/Jeandle/VMCallback.h"
@@ -42,6 +46,7 @@ STATISTIC(NumFieldsFolded, "Number of constant field loads folded");
 STATISTIC(NumKlassesFolded, "Number of jeandle.load_klass calls folded");
 STATISTIC(NumMirrorKlassesFolded,
           "Number of jeandle.load_mirror_klass calls folded");
+STATISTIC(NumGetClassesFolded, "Number of jeandle.get_class calls folded");
 STATISTIC(NumKlassLayoutHelpersFolded,
           "Number of jeandle.layout_helper calls folded");
 STATISTIC(NumKlassInitializedFolded,
@@ -354,6 +359,43 @@ bool isKlassInitializedCall(CallInst *CI) {
          CI->arg_size() == 1;
 }
 
+bool isGetClassCall(CallInst *CI) {
+  Function *Callee = CI ? CI->getCalledFunction() : nullptr;
+  return Callee && Callee->getName() == "jeandle.get_class" &&
+         CI->arg_size() == 1;
+}
+
+bool foldGetClassCall(CallInst *CI, const jeandle::VMCallbacks &CB,
+                      DominatorTree &DT, const DataLayout &DL) {
+  if (!isGetClassCall(CI) || !isJavaOopType(CI->getType()) || !CB.GetJavaMirror)
+    return false;
+
+  // The frontend emits a null check before Object.getClass. Require LLVM to
+  // prove that the receiver is non-null at this call site as well, so this
+  // fold cannot accidentally remove the Java-required NullPointerException.
+  SimplifyQuery SQ(DL, &DT, nullptr, CI);
+  if (!isKnownNonZero(CI->getArgOperand(0), SQ))
+    return false;
+
+  jeandle::JavaType ReceiverType =
+      jeandle::getJavaType(CI->getArgOperand(0), &DT, CI);
+  if (!ReceiverType.isKnown() || !ReceiverType.Exact)
+    return false;
+
+  int MirrorOopId = CB.GetJavaMirror(ReceiverType.Klass);
+  if (MirrorOopId < 0)
+    return false;
+
+  Module *M = CI->getModule();
+  if (!M)
+    return false;
+  IRBuilder<> Builder(CI);
+  LoadInst *Mirror = createConstOopLoad(*M, Builder, MirrorOopId);
+  CI->replaceAllUsesWith(Mirror);
+  CI->eraseFromParent();
+  return true;
+}
+
 bool foldLoadKlassCall(CallInst *CI, const jeandle::VMCallbacks &CB,
                        const DenseMap<Value *, int> &ConstOops) {
   if (!isLoadKlassCall(CI) || !CB.GetOopKlass)
@@ -656,9 +698,11 @@ PreservedAnalyses ConstantFieldFolding::run(Function &F,
     RoundChanged = false;
     DenseMap<Value *, int> ConstOops = computeConstOops(F);
     ReversePostOrderTraversal<Function *> RPOT(&F);
+    DominatorTree &DT = FAM.getResult<DominatorTreeAnalysis>(F);
 
     SmallVector<CallInst *, 16> LoadKlassCalls;
     SmallVector<CallInst *, 16> LoadMirrorKlassCalls;
+    SmallVector<CallInst *, 16> GetClassCalls;
     SmallVector<CallInst *, 16> LayoutHelperCalls;
     SmallVector<CallInst *, 16> KlassInitializedCalls;
     SmallVector<LoadInst *, 16> Loads;
@@ -669,6 +713,8 @@ PreservedAnalyses ConstantFieldFolding::run(Function &F,
             LoadKlassCalls.push_back(CI);
           if (isLoadMirrorKlassCall(CI))
             LoadMirrorKlassCalls.push_back(CI);
+          if (isGetClassCall(CI))
+            GetClassCalls.push_back(CI);
           if (isLayoutHelperCall(CI))
             LayoutHelperCalls.push_back(CI);
           if (isKlassInitializedCall(CI))
@@ -696,6 +742,16 @@ PreservedAnalyses ConstantFieldFolding::run(Function &F,
         continue;
       if (foldLoadMirrorKlassCall(CI, *CB, ConstOops)) {
         ++NumMirrorKlassesFolded;
+        RoundChanged = true;
+        Changed = true;
+      }
+    }
+
+    for (CallInst *CI : GetClassCalls) {
+      if (CI->getParent() == nullptr)
+        continue;
+      if (foldGetClassCall(CI, *CB, DT, DL)) {
+        ++NumGetClassesFolded;
         RoundChanged = true;
         Changed = true;
       }

--- a/llvm/lib/Transforms/Jeandle/ConstantFieldFolding.cpp
+++ b/llvm/lib/Transforms/Jeandle/ConstantFieldFolding.cpp
@@ -38,6 +38,11 @@
 using namespace llvm;
 
 STATISTIC(NumFieldsFolded, "Number of constant field loads folded");
+STATISTIC(NumKlassesFolded, "Number of jeandle.load_klass calls folded");
+STATISTIC(NumMirrorKlassesFolded,
+          "Number of jeandle.load_mirror_klass calls folded");
+STATISTIC(NumKlassLayoutHelpersFolded,
+          "Number of jeandle.layout_helper calls folded");
 STATISTIC(NumRounds, "Number of folding rounds");
 STATISTIC(NumOopChains, "Number of oop chains followed");
 
@@ -308,6 +313,115 @@ matchFieldLoad(LoadInst *LI, const DenseMap<Value *, int> &ConstOops,
   return FieldLoadMatch{LI, ImmediateGEP, *BaseId, OffsetVal};
 }
 
+std::optional<uintptr_t> getConstantKlassPointer(Value *V) {
+  V = V->stripPointerCasts();
+  if (auto *CE = dyn_cast<ConstantExpr>(V)) {
+    if (CE->getOpcode() != Instruction::IntToPtr || CE->getNumOperands() != 1)
+      return std::nullopt;
+    if (auto *CI = dyn_cast<ConstantInt>(CE->getOperand(0)))
+      return static_cast<uintptr_t>(CI->getZExtValue());
+    return std::nullopt;
+  }
+  if (auto *CI = dyn_cast<ConstantInt>(V))
+    return static_cast<uintptr_t>(CI->getZExtValue());
+  return std::nullopt;
+}
+
+Constant *klassPointerConstant(LLVMContext &Ctx, Type *Ty, uintptr_t Klass) {
+  if (Klass == 0 || !Ty->isPointerTy())
+    return nullptr;
+  return ConstantExpr::getIntToPtr(
+      ConstantInt::get(Type::getInt64Ty(Ctx), Klass), Ty);
+}
+
+bool isLoadKlassCall(CallInst *CI) {
+  Function *Callee = CI ? CI->getCalledFunction() : nullptr;
+  return Callee && Callee->getName() == "jeandle.load_klass" &&
+         CI->arg_size() == 1;
+}
+
+bool isLoadMirrorKlassCall(CallInst *CI) {
+  Function *Callee = CI ? CI->getCalledFunction() : nullptr;
+  return Callee && Callee->getName() == "jeandle.load_mirror_klass" &&
+         CI->arg_size() == 1;
+}
+
+bool isLayoutHelperCall(CallInst *CI) {
+  Function *Callee = CI ? CI->getCalledFunction() : nullptr;
+  return Callee && Callee->getName() == "jeandle.layout_helper" &&
+         CI->arg_size() == 1;
+}
+
+bool foldLoadKlassCall(CallInst *CI, const jeandle::VMCallbacks &CB,
+                       const DenseMap<Value *, int> &ConstOops) {
+  if (!isLoadKlassCall(CI) || !CB.GetOopKlass)
+    return false;
+
+  std::optional<int> OopId =
+      lookupConstOop(CI->getArgOperand(0), ConstOops);
+  if (!OopId)
+    return false;
+
+  uintptr_t Klass = CB.GetOopKlass(*OopId);
+  Constant *KlassConstant =
+      klassPointerConstant(CI->getContext(), CI->getType(), Klass);
+  if (!KlassConstant)
+    return false;
+
+  CI->replaceAllUsesWith(KlassConstant);
+  CI->eraseFromParent();
+  return true;
+}
+
+bool foldLoadMirrorKlassCall(CallInst *CI, const jeandle::VMCallbacks &CB,
+                             const DenseMap<Value *, int> &ConstOops) {
+  if (!isLoadMirrorKlassCall(CI) || !CI->getType()->isPointerTy() ||
+      !CB.GetMirrorKlass)
+    return false;
+
+  std::optional<int> OopId =
+      lookupConstOop(CI->getArgOperand(0), ConstOops);
+  if (!OopId)
+    return false;
+
+  uintptr_t Klass = CB.GetMirrorKlass(*OopId);
+  if (Klass == jeandle::MirrorKlassUnavailable)
+    return false;
+
+  Constant *KlassConstant;
+  if (Klass == 0)
+    KlassConstant =
+        ConstantPointerNull::get(cast<PointerType>(CI->getType()));
+  else
+    KlassConstant =
+        klassPointerConstant(CI->getContext(), CI->getType(), Klass);
+  if (!KlassConstant)
+    return false;
+
+  CI->replaceAllUsesWith(KlassConstant);
+  CI->eraseFromParent();
+  return true;
+}
+
+bool foldLayoutHelperCall(CallInst *CI, const jeandle::VMCallbacks &CB) {
+  if (!isLayoutHelperCall(CI) || !CI->getType()->isIntegerTy(32) ||
+      !CB.GetKlassLayoutHelper)
+    return false;
+
+  std::optional<uintptr_t> Klass =
+      getConstantKlassPointer(CI->getArgOperand(0));
+  if (!Klass || *Klass == 0)
+    return false;
+
+  int LayoutHelper = CB.GetKlassLayoutHelper(*Klass);
+  if (LayoutHelper == 0)
+    return false;
+
+  CI->replaceAllUsesWith(ConstantInt::get(CI->getType(), LayoutHelper));
+  CI->eraseFromParent();
+  return true;
+}
+
 bool isSubIntBasicType(int BasicType) {
   return BasicType == T_BOOLEAN || BasicType == T_BYTE || BasicType == T_CHAR ||
          BasicType == T_SHORT;
@@ -536,15 +650,61 @@ PreservedAnalyses ConstantFieldFolding::run(Function &F,
     DenseMap<Value *, int> ConstOops = computeConstOops(F);
     ReversePostOrderTraversal<Function *> RPOT(&F);
 
+    SmallVector<CallInst *, 16> LoadKlassCalls;
+    SmallVector<CallInst *, 16> LoadMirrorKlassCalls;
+    SmallVector<CallInst *, 16> LayoutHelperCalls;
     SmallVector<LoadInst *, 16> Loads;
     for (BasicBlock *BB : RPOT) {
       for (Instruction &I : *BB) {
+        if (auto *CI = dyn_cast<CallInst>(&I)) {
+          if (isLoadKlassCall(CI))
+            LoadKlassCalls.push_back(CI);
+          if (isLoadMirrorKlassCall(CI))
+            LoadMirrorKlassCalls.push_back(CI);
+          if (isLayoutHelperCall(CI))
+            LayoutHelperCalls.push_back(CI);
+        }
         if (auto *LI = dyn_cast<LoadInst>(&I))
           Loads.push_back(LI);
       }
     }
 
+    // Fold object Klass loads before layout-helper queries so that a complete
+    // constant-oop -> Klass* -> layout-helper chain collapses in one round.
+    for (CallInst *CI : LoadKlassCalls) {
+      if (CI->getParent() == nullptr)
+        continue;
+      if (foldLoadKlassCall(CI, *CB, ConstOops)) {
+        ++NumKlassesFolded;
+        RoundChanged = true;
+        Changed = true;
+      }
+    }
+
+    for (CallInst *CI : LoadMirrorKlassCalls) {
+      if (CI->getParent() == nullptr)
+        continue;
+      if (foldLoadMirrorKlassCall(CI, *CB, ConstOops)) {
+        ++NumMirrorKlassesFolded;
+        RoundChanged = true;
+        Changed = true;
+      }
+    }
+
+    for (CallInst *CI : LayoutHelperCalls) {
+      if (CI->getParent() == nullptr)
+        continue;
+      if (foldLayoutHelperCall(CI, *CB)) {
+        ++NumKlassLayoutHelpersFolded;
+        RoundChanged = true;
+        Changed = true;
+      }
+    }
+
     for (LoadInst *LI : Loads) {
+      if (LI->getParent() == nullptr)
+        continue;
+
       std::optional<FieldLoadMatch> Match = matchFieldLoad(LI, ConstOops, DL);
       if (!Match)
         continue;

--- a/llvm/lib/Transforms/Jeandle/ConstantFieldFolding.cpp
+++ b/llvm/lib/Transforms/Jeandle/ConstantFieldFolding.cpp
@@ -39,6 +39,13 @@
 using namespace llvm;
 
 STATISTIC(NumFieldsFolded, "Number of constant field loads folded");
+STATISTIC(NumKlassesFolded, "Number of jeandle.load_klass calls folded");
+STATISTIC(NumMirrorKlassesFolded,
+          "Number of jeandle.load_mirror_klass calls folded");
+STATISTIC(NumKlassLayoutHelpersFolded,
+          "Number of jeandle.layout_helper calls folded");
+STATISTIC(NumKlassInitializedFolded,
+          "Number of jeandle.klass_is_initialized calls folded");
 STATISTIC(NumRounds, "Number of folding rounds");
 STATISTIC(NumOopChains, "Number of oop chains followed");
 
@@ -302,6 +309,140 @@ matchFieldLoad(LoadInst *LI, const DenseMap<Value *, int> &ConstOops,
   return FieldLoadMatch{LI, ImmediateGEP, *BaseId, OffsetVal};
 }
 
+std::optional<uintptr_t> getConstantKlassPointer(Value *V) {
+  V = V->stripPointerCasts();
+  if (auto *CE = dyn_cast<ConstantExpr>(V)) {
+    if (CE->getOpcode() != Instruction::IntToPtr || CE->getNumOperands() != 1)
+      return std::nullopt;
+    if (auto *CI = dyn_cast<ConstantInt>(CE->getOperand(0)))
+      return static_cast<uintptr_t>(CI->getZExtValue());
+    return std::nullopt;
+  }
+  if (auto *CI = dyn_cast<ConstantInt>(V))
+    return static_cast<uintptr_t>(CI->getZExtValue());
+  return std::nullopt;
+}
+
+Constant *klassPointerConstant(LLVMContext &Ctx, Type *Ty, uintptr_t Klass) {
+  if (Klass == 0 || !Ty->isPointerTy())
+    return nullptr;
+  return ConstantExpr::getIntToPtr(
+      ConstantInt::get(Type::getInt64Ty(Ctx), Klass), Ty);
+}
+
+bool isLoadKlassCall(CallInst *CI) {
+  Function *Callee = CI ? CI->getCalledFunction() : nullptr;
+  return Callee && Callee->getName() == "jeandle.load_klass" &&
+         CI->arg_size() == 1;
+}
+
+bool isLoadMirrorKlassCall(CallInst *CI) {
+  Function *Callee = CI ? CI->getCalledFunction() : nullptr;
+  return Callee && Callee->getName() == "jeandle.load_mirror_klass" &&
+         CI->arg_size() == 1;
+}
+
+bool isLayoutHelperCall(CallInst *CI) {
+  Function *Callee = CI ? CI->getCalledFunction() : nullptr;
+  return Callee && Callee->getName() == "jeandle.layout_helper" &&
+         CI->arg_size() == 1;
+}
+
+bool isKlassInitializedCall(CallInst *CI) {
+  Function *Callee = CI ? CI->getCalledFunction() : nullptr;
+  return Callee && Callee->getName() == "jeandle.klass_is_initialized" &&
+         CI->arg_size() == 1;
+}
+
+bool foldLoadKlassCall(CallInst *CI, const jeandle::VMCallbacks &CB,
+                       const DenseMap<Value *, int> &ConstOops) {
+  if (!isLoadKlassCall(CI) || !CB.GetOopKlass)
+    return false;
+
+  std::optional<int> OopId = lookupConstOop(CI->getArgOperand(0), ConstOops);
+  if (!OopId)
+    return false;
+
+  uintptr_t Klass = CB.GetOopKlass(*OopId);
+  Constant *KlassConstant =
+      klassPointerConstant(CI->getContext(), CI->getType(), Klass);
+  if (!KlassConstant)
+    return false;
+
+  CI->replaceAllUsesWith(KlassConstant);
+  CI->eraseFromParent();
+  return true;
+}
+
+bool foldLoadMirrorKlassCall(CallInst *CI, const jeandle::VMCallbacks &CB,
+                             const DenseMap<Value *, int> &ConstOops) {
+  if (!isLoadMirrorKlassCall(CI) || !CI->getType()->isPointerTy() ||
+      !CB.GetMirrorKlass)
+    return false;
+
+  std::optional<int> OopId = lookupConstOop(CI->getArgOperand(0), ConstOops);
+  if (!OopId)
+    return false;
+
+  uintptr_t Klass = CB.GetMirrorKlass(*OopId);
+  if (Klass == jeandle::MirrorKlassUnavailable)
+    return false;
+
+  Constant *KlassConstant;
+  if (Klass == 0)
+    KlassConstant = ConstantPointerNull::get(cast<PointerType>(CI->getType()));
+  else
+    KlassConstant =
+        klassPointerConstant(CI->getContext(), CI->getType(), Klass);
+  if (!KlassConstant)
+    return false;
+
+  CI->replaceAllUsesWith(KlassConstant);
+  CI->eraseFromParent();
+  return true;
+}
+
+bool foldLayoutHelperCall(CallInst *CI, const jeandle::VMCallbacks &CB) {
+  if (!isLayoutHelperCall(CI) || !CI->getType()->isIntegerTy(32) ||
+      !CB.GetKlassLayoutHelper)
+    return false;
+
+  std::optional<uintptr_t> Klass =
+      getConstantKlassPointer(CI->getArgOperand(0));
+  if (!Klass || *Klass == 0)
+    return false;
+
+  int LayoutHelper = CB.GetKlassLayoutHelper(*Klass);
+  if (LayoutHelper == 0)
+    return false;
+
+  CI->replaceAllUsesWith(ConstantInt::get(CI->getType(), LayoutHelper));
+  CI->eraseFromParent();
+  return true;
+}
+
+bool foldKlassInitializedCall(CallInst *CI, const jeandle::VMCallbacks &CB) {
+  if (!isKlassInitializedCall(CI) || !CI->getType()->isIntegerTy(1) ||
+      !CB.IsKlassInitialized)
+    return false;
+
+  std::optional<uintptr_t> Klass =
+      getConstantKlassPointer(CI->getArgOperand(0));
+  if (!Klass || *Klass == 0)
+    return false;
+
+  // Initialization is monotonic. A class known to be fully initialized at
+  // compile time stays initialized, so replacing the query with true is safe.
+  // A false result is only a snapshot: the class may initialize before this
+  // code executes, so retain the JavaOp and its dynamic load.
+  if (!CB.IsKlassInitialized(*Klass))
+    return false;
+
+  CI->replaceAllUsesWith(ConstantInt::getTrue(CI->getContext()));
+  CI->eraseFromParent();
+  return true;
+}
+
 bool isSubIntBasicType(int BasicType) {
   return BasicType == T_BOOLEAN || BasicType == T_BYTE || BasicType == T_CHAR ||
          BasicType == T_SHORT;
@@ -516,15 +657,74 @@ PreservedAnalyses ConstantFieldFolding::run(Function &F,
     DenseMap<Value *, int> ConstOops = computeConstOops(F);
     ReversePostOrderTraversal<Function *> RPOT(&F);
 
+    SmallVector<CallInst *, 16> LoadKlassCalls;
+    SmallVector<CallInst *, 16> LoadMirrorKlassCalls;
+    SmallVector<CallInst *, 16> LayoutHelperCalls;
+    SmallVector<CallInst *, 16> KlassInitializedCalls;
     SmallVector<LoadInst *, 16> Loads;
     for (BasicBlock *BB : RPOT) {
       for (Instruction &I : *BB) {
+        if (auto *CI = dyn_cast<CallInst>(&I)) {
+          if (isLoadKlassCall(CI))
+            LoadKlassCalls.push_back(CI);
+          if (isLoadMirrorKlassCall(CI))
+            LoadMirrorKlassCalls.push_back(CI);
+          if (isLayoutHelperCall(CI))
+            LayoutHelperCalls.push_back(CI);
+          if (isKlassInitializedCall(CI))
+            KlassInitializedCalls.push_back(CI);
+        }
         if (auto *LI = dyn_cast<LoadInst>(&I))
           Loads.push_back(LI);
       }
     }
 
+    // Fold object Klass loads before layout-helper queries so that a complete
+    // constant-oop -> Klass* -> layout-helper chain collapses in one round.
+    for (CallInst *CI : LoadKlassCalls) {
+      if (CI->getParent() == nullptr)
+        continue;
+      if (foldLoadKlassCall(CI, *CB, ConstOops)) {
+        ++NumKlassesFolded;
+        RoundChanged = true;
+        Changed = true;
+      }
+    }
+
+    for (CallInst *CI : LoadMirrorKlassCalls) {
+      if (CI->getParent() == nullptr)
+        continue;
+      if (foldLoadMirrorKlassCall(CI, *CB, ConstOops)) {
+        ++NumMirrorKlassesFolded;
+        RoundChanged = true;
+        Changed = true;
+      }
+    }
+
+    for (CallInst *CI : LayoutHelperCalls) {
+      if (CI->getParent() == nullptr)
+        continue;
+      if (foldLayoutHelperCall(CI, *CB)) {
+        ++NumKlassLayoutHelpersFolded;
+        RoundChanged = true;
+        Changed = true;
+      }
+    }
+
+    for (CallInst *CI : KlassInitializedCalls) {
+      if (CI->getParent() == nullptr)
+        continue;
+      if (foldKlassInitializedCall(CI, *CB)) {
+        ++NumKlassInitializedFolded;
+        RoundChanged = true;
+        Changed = true;
+      }
+    }
+
     for (LoadInst *LI : Loads) {
+      if (LI->getParent() == nullptr)
+        continue;
+
       std::optional<FieldLoadMatch> Match = matchFieldLoad(LI, ConstOops, DL);
       if (!Match)
         continue;

--- a/llvm/lib/Transforms/Jeandle/JeandleTransformUtils.cpp
+++ b/llvm/lib/Transforms/Jeandle/JeandleTransformUtils.cpp
@@ -319,7 +319,9 @@ LoadInst *createConstOopLoad(Module &M, IRBuilder<> &Builder, int OopId) {
   std::string Name = CB->GetOopHandleName(OopId);
   GlobalVariable *GV = cast<GlobalVariable>(M.getOrInsertGlobal(Name, OopTy));
   GV->setDSOLocal(true);
-  return Builder.CreateLoad(OopTy, GV, "folded.oop");
+  LoadInst *LI = Builder.CreateLoad(OopTy, GV, "folded.oop");
+  LI->setMetadata(LLVMContext::MD_nonnull, MDNode::get(Ctx, {}));
+  return LI;
 }
 
 void appendVirtualObjectDescriptor(SmallVectorImpl<Value *> &Args,

--- a/llvm/test/Jeandle/constant-field-folding/Inputs/get-class.cblog
+++ b/llvm/test/Jeandle/constant-field-folding/Inputs/get-class.cblog
@@ -1,0 +1,2 @@
+GetJavaMirror 123 = 7
+GetOopHandleName 7 = "oop_handle_Mirror_7"

--- a/llvm/test/Jeandle/constant-field-folding/Inputs/get-class.cblog
+++ b/llvm/test/Jeandle/constant-field-folding/Inputs/get-class.cblog
@@ -1,2 +1,4 @@
+GetOopKlass 0 = 123
+GetOopKlass 1 = 0
 GetJavaMirror 123 = 7
 GetOopHandleName 7 = "oop_handle_Mirror_7"

--- a/llvm/test/Jeandle/constant-field-folding/Inputs/klass-is-initialized.cblog
+++ b/llvm/test/Jeandle/constant-field-folding/Inputs/klass-is-initialized.cblog
@@ -1,0 +1,2 @@
+IsKlassInitialized 123456 = true
+IsKlassInitialized 654321 = false

--- a/llvm/test/Jeandle/constant-field-folding/Inputs/klass-layout-chain.cblog
+++ b/llvm/test/Jeandle/constant-field-folding/Inputs/klass-layout-chain.cblog
@@ -1,0 +1,2 @@
+GetOopKlass 0 = 123456
+GetKlassLayoutHelper 123456 = -2147483637

--- a/llvm/test/Jeandle/constant-field-folding/Inputs/layout-helper-call.cblog
+++ b/llvm/test/Jeandle/constant-field-folding/Inputs/layout-helper-call.cblog
@@ -1,0 +1,2 @@
+GetKlassLayoutHelper 123456 = -2147483637
+GetKlassLayoutHelper 654321 = 0

--- a/llvm/test/Jeandle/constant-field-folding/Inputs/load-klass.cblog
+++ b/llvm/test/Jeandle/constant-field-folding/Inputs/load-klass.cblog
@@ -1,2 +1,3 @@
 GetOopKlass 0 = 123456
 GetOopKlass 1 = 0
+GetKlassConstant 123456 = 123456

--- a/llvm/test/Jeandle/constant-field-folding/Inputs/load-klass.cblog
+++ b/llvm/test/Jeandle/constant-field-folding/Inputs/load-klass.cblog
@@ -1,0 +1,2 @@
+GetOopKlass 0 = 123456
+GetOopKlass 1 = 0

--- a/llvm/test/Jeandle/constant-field-folding/Inputs/load-mirror-klass.cblog
+++ b/llvm/test/Jeandle/constant-field-folding/Inputs/load-mirror-klass.cblog
@@ -1,0 +1,3 @@
+GetMirrorKlass 0 = 234567
+GetMirrorKlass 1 = 0
+GetMirrorKlass 2 = 18446744073709551615

--- a/llvm/test/Jeandle/constant-field-folding/Inputs/mirror-klass-initialized-chain.cblog
+++ b/llvm/test/Jeandle/constant-field-folding/Inputs/mirror-klass-initialized-chain.cblog
@@ -1,0 +1,2 @@
+GetMirrorKlass 0 = 123456
+IsKlassInitialized 123456 = true

--- a/llvm/test/Jeandle/constant-field-folding/Inputs/mirror-klass-layout-chain.cblog
+++ b/llvm/test/Jeandle/constant-field-folding/Inputs/mirror-klass-layout-chain.cblog
@@ -1,0 +1,4 @@
+GetConstantField 0 16 = (12, 1)
+GetOopHandleName 1 = "oop_handle_ClassMirror_1"
+GetMirrorKlass 1 = 234567
+GetKlassLayoutHelper 234567 = -2147483637

--- a/llvm/test/Jeandle/constant-field-folding/Inputs/mirror-klass-layout-chain.cblog
+++ b/llvm/test/Jeandle/constant-field-folding/Inputs/mirror-klass-layout-chain.cblog
@@ -1,0 +1,5 @@
+GetConstantFieldInfo 0 16 = 12
+GetConstantFieldValue 0 16 = 1
+GetOopHandleName 1 = "oop_handle_ClassMirror_1"
+GetMirrorKlass 1 = 234567
+GetKlassLayoutHelper 234567 = -2147483637

--- a/llvm/test/Jeandle/constant-field-folding/get-class.ll
+++ b/llvm/test/Jeandle/constant-field-folding/get-class.ll
@@ -1,0 +1,50 @@
+; RUN: opt -S -passes="constant-field-folding" -jeandle-vm-callback-log=%S/Inputs/get-class.cblog %s 2>&1 | FileCheck %s
+
+@oop_handle_Mirror_7 = external dso_local global ptr addrspace(1)
+
+declare hotspotcc ptr addrspace(1) @jeandle.get_class(ptr addrspace(1))
+
+; An exact, non-null receiver can use the Class mirror oop handle directly.
+define hotspotcc ptr addrspace(1) @fold_exact(
+    ptr addrspace(1) nonnull "java-klass"="123" "java-klass-exact" %obj)
+    #0 gc "hotspotgc" {
+entry:
+  %mirror = call hotspotcc ptr addrspace(1)
+      @jeandle.get_class(ptr addrspace(1) %obj)
+  ret ptr addrspace(1) %mirror
+}
+
+; A declared-but-not-exact type may hold a subclass, so getClass remains.
+define hotspotcc ptr addrspace(1) @keep_nonexact(
+    ptr addrspace(1) nonnull "java-klass"="123" %obj)
+    #0 gc "hotspotgc" {
+entry:
+  %mirror = call hotspotcc ptr addrspace(1)
+      @jeandle.get_class(ptr addrspace(1) %obj)
+  ret ptr addrspace(1) %mirror
+}
+
+; Exact type without a non-null proof must retain the call's NPE behavior.
+define hotspotcc ptr addrspace(1) @keep_nullable(
+    ptr addrspace(1) "java-klass"="123" "java-klass-exact" %obj)
+    #0 gc "hotspotgc" {
+entry:
+  %mirror = call hotspotcc ptr addrspace(1)
+      @jeandle.get_class(ptr addrspace(1) %obj)
+  ret ptr addrspace(1) %mirror
+}
+
+; CHECK-LABEL: define hotspotcc ptr addrspace(1) @fold_exact
+; CHECK-NOT: call hotspotcc ptr addrspace(1) @jeandle.get_class
+; CHECK: load ptr addrspace(1), ptr @oop_handle_Mirror_7
+; CHECK: ret ptr addrspace(1)
+
+; CHECK-LABEL: define hotspotcc ptr addrspace(1) @keep_nonexact
+; CHECK: call hotspotcc ptr addrspace(1) @jeandle.get_class
+
+; CHECK-LABEL: define hotspotcc ptr addrspace(1) @keep_nullable
+; CHECK: call hotspotcc ptr addrspace(1) @jeandle.get_class
+
+attributes #0 = { "java-method"="1" }
+
+!java-method-compilation = !{}

--- a/llvm/test/Jeandle/constant-field-folding/get-class.ll
+++ b/llvm/test/Jeandle/constant-field-folding/get-class.ll
@@ -1,6 +1,8 @@
 ; RUN: opt -S -passes="constant-field-folding" -jeandle-vm-callback-log=%S/Inputs/get-class.cblog %s 2>&1 | FileCheck %s
 
 @oop_handle_Mirror_7 = external dso_local global ptr addrspace(1)
+@oop_handle_Test_0 = external dso_local global ptr addrspace(1)
+@oop_handle_Null_1 = external dso_local global ptr addrspace(1)
 
 declare hotspotcc ptr addrspace(1) @jeandle.get_class(ptr addrspace(1))
 
@@ -9,6 +11,25 @@ define hotspotcc ptr addrspace(1) @fold_exact(
     ptr addrspace(1) nonnull "java-klass"="123" "java-klass-exact" %obj)
     #0 gc "hotspotgc" {
 entry:
+  %mirror = call hotspotcc ptr addrspace(1)
+      @jeandle.get_class(ptr addrspace(1) %obj)
+  ret ptr addrspace(1) %mirror
+}
+
+; A constant oop receiver can be folded through its actual dynamic Klass even
+; without Java type attributes on the receiver.
+define hotspotcc ptr addrspace(1) @fold_constant_oop() #0 gc "hotspotgc" {
+entry:
+  %obj = load ptr addrspace(1), ptr @oop_handle_Test_0
+  %mirror = call hotspotcc ptr addrspace(1)
+      @jeandle.get_class(ptr addrspace(1) %obj)
+  ret ptr addrspace(1) %mirror
+}
+
+; A constant null receiver must retain get_class for its NPE behavior.
+define hotspotcc ptr addrspace(1) @keep_constant_null() #0 gc "hotspotgc" {
+entry:
+  %obj = load ptr addrspace(1), ptr @oop_handle_Null_1
   %mirror = call hotspotcc ptr addrspace(1)
       @jeandle.get_class(ptr addrspace(1) %obj)
   ret ptr addrspace(1) %mirror
@@ -38,6 +59,13 @@ entry:
 ; CHECK-NOT: call hotspotcc ptr addrspace(1) @jeandle.get_class
 ; CHECK: load ptr addrspace(1), ptr @oop_handle_Mirror_7
 ; CHECK: ret ptr addrspace(1)
+
+; CHECK-LABEL: define hotspotcc ptr addrspace(1) @fold_constant_oop()
+; CHECK:       %obj = load ptr addrspace(1), ptr @oop_handle_Test_0
+; CHECK:       load ptr addrspace(1), ptr @oop_handle_Mirror_7
+
+; CHECK-LABEL: define hotspotcc ptr addrspace(1) @keep_constant_null()
+; CHECK:       call hotspotcc ptr addrspace(1) @jeandle.get_class
 
 ; CHECK-LABEL: define hotspotcc ptr addrspace(1) @keep_nonexact
 ; CHECK: call hotspotcc ptr addrspace(1) @jeandle.get_class

--- a/llvm/test/Jeandle/constant-field-folding/klass-is-initialized.ll
+++ b/llvm/test/Jeandle/constant-field-folding/klass-is-initialized.ll
@@ -1,0 +1,48 @@
+; RUN: opt -S -passes="constant-field-folding" -jeandle-vm-callback-log=%S/Inputs/klass-is-initialized.cblog %s 2>&1 | FileCheck %s
+
+declare hotspotcc i1 @jeandle.klass_is_initialized(ptr)
+
+define hotspotcc i1 @fold_initialized() #0 gc "hotspotgc" {
+entry:
+  %initialized = call hotspotcc i1 @jeandle.klass_is_initialized(ptr inttoptr (i64 123456 to ptr))
+  ret i1 %initialized
+}
+
+; CHECK-LABEL: define hotspotcc i1 @fold_initialized()
+; CHECK:       entry:
+; CHECK-NEXT:    ret i1 true
+
+; A false VM answer is not stable: the class can initialize before execution.
+define hotspotcc i1 @keep_not_yet_initialized() #0 gc "hotspotgc" {
+entry:
+  %initialized = call hotspotcc i1 @jeandle.klass_is_initialized(ptr inttoptr (i64 654321 to ptr))
+  ret i1 %initialized
+}
+
+; CHECK-LABEL: define hotspotcc i1 @keep_not_yet_initialized()
+; CHECK:         %initialized = call hotspotcc i1 @jeandle.klass_is_initialized(ptr inttoptr (i64 654321 to ptr))
+; CHECK-NEXT:    ret i1 %initialized
+
+define hotspotcc i1 @keep_dynamic(ptr %klass) #0 gc "hotspotgc" {
+entry:
+  %initialized = call hotspotcc i1 @jeandle.klass_is_initialized(ptr %klass)
+  ret i1 %initialized
+}
+
+; CHECK-LABEL: define hotspotcc i1 @keep_dynamic(
+; CHECK:         %initialized = call hotspotcc i1 @jeandle.klass_is_initialized(ptr %klass)
+; CHECK-NEXT:    ret i1 %initialized
+
+define hotspotcc i1 @keep_null() #0 gc "hotspotgc" {
+entry:
+  %initialized = call hotspotcc i1 @jeandle.klass_is_initialized(ptr null)
+  ret i1 %initialized
+}
+
+; CHECK-LABEL: define hotspotcc i1 @keep_null()
+; CHECK:         %initialized = call hotspotcc i1 @jeandle.klass_is_initialized(ptr null)
+; CHECK-NEXT:    ret i1 %initialized
+
+attributes #0 = { "java-method"="1" }
+
+!java-method-compilation = !{}

--- a/llvm/test/Jeandle/constant-field-folding/klass-layout-chain.ll
+++ b/llvm/test/Jeandle/constant-field-folding/klass-layout-chain.ll
@@ -1,0 +1,23 @@
+; RUN: opt -S -passes="constant-field-folding" -jeandle-vm-callback-log=%S/Inputs/klass-layout-chain.cblog %s 2>&1 | FileCheck %s
+
+@oop_handle_Test_0 = external dso_local global ptr addrspace(1)
+
+declare hotspotcc ptr @jeandle.load_klass(ptr addrspace(1))
+declare hotspotcc i32 @jeandle.layout_helper(ptr)
+
+define hotspotcc i32 @fold_klass_layout_chain() #0 gc "hotspotgc" {
+entry:
+  %obj = load ptr addrspace(1), ptr @oop_handle_Test_0
+  %klass = call hotspotcc ptr @jeandle.load_klass(ptr addrspace(1) %obj)
+  %layout = call hotspotcc i32 @jeandle.layout_helper(ptr %klass)
+  ret i32 %layout
+}
+
+; CHECK-LABEL: define hotspotcc i32 @fold_klass_layout_chain()
+; CHECK:       entry:
+; CHECK-NEXT:    %obj = load ptr addrspace(1), ptr @oop_handle_Test_0
+; CHECK-NEXT:    ret i32 -2147483637
+
+attributes #0 = { "java-method"="1" }
+
+!java-method-compilation = !{}

--- a/llvm/test/Jeandle/constant-field-folding/layout-helper-call.ll
+++ b/llvm/test/Jeandle/constant-field-folding/layout-helper-call.ll
@@ -1,0 +1,47 @@
+; RUN: opt -S -passes="constant-field-folding" -jeandle-vm-callback-log=%S/Inputs/layout-helper-call.cblog %s 2>&1 | FileCheck %s
+
+declare hotspotcc i32 @jeandle.layout_helper(ptr)
+
+define hotspotcc i32 @fold_layout_helper() #0 gc "hotspotgc" {
+entry:
+  %layout = call hotspotcc i32 @jeandle.layout_helper(ptr inttoptr (i64 123456 to ptr))
+  ret i32 %layout
+}
+
+; CHECK-LABEL: define hotspotcc i32 @fold_layout_helper()
+; CHECK:       entry:
+; CHECK-NEXT:    ret i32 -2147483637
+
+define hotspotcc i32 @keep_dynamic(ptr %klass) #0 gc "hotspotgc" {
+entry:
+  %layout = call hotspotcc i32 @jeandle.layout_helper(ptr %klass)
+  ret i32 %layout
+}
+
+; CHECK-LABEL: define hotspotcc i32 @keep_dynamic(
+; CHECK:         %layout = call hotspotcc i32 @jeandle.layout_helper(ptr %klass)
+; CHECK-NEXT:    ret i32 %layout
+
+define hotspotcc i32 @keep_null() #0 gc "hotspotgc" {
+entry:
+  %layout = call hotspotcc i32 @jeandle.layout_helper(ptr null)
+  ret i32 %layout
+}
+
+; CHECK-LABEL: define hotspotcc i32 @keep_null()
+; CHECK:         %layout = call hotspotcc i32 @jeandle.layout_helper(ptr null)
+; CHECK-NEXT:    ret i32 %layout
+
+define hotspotcc i32 @keep_unavailable() #0 gc "hotspotgc" {
+entry:
+  %layout = call hotspotcc i32 @jeandle.layout_helper(ptr inttoptr (i64 654321 to ptr))
+  ret i32 %layout
+}
+
+; CHECK-LABEL: define hotspotcc i32 @keep_unavailable()
+; CHECK:         %layout = call hotspotcc i32 @jeandle.layout_helper(ptr inttoptr (i64 654321 to ptr))
+; CHECK-NEXT:    ret i32 %layout
+
+attributes #0 = { "java-method"="1" }
+
+!java-method-compilation = !{}

--- a/llvm/test/Jeandle/constant-field-folding/load-klass.ll
+++ b/llvm/test/Jeandle/constant-field-folding/load-klass.ll
@@ -1,0 +1,65 @@
+; RUN: opt -S -passes="constant-field-folding" -jeandle-vm-callback-log=%S/Inputs/load-klass.cblog %s 2>&1 | FileCheck %s
+
+@oop_handle_Test_0 = external dso_local global ptr addrspace(1)
+@oop_handle_Test_1 = external dso_local global ptr addrspace(1)
+
+declare hotspotcc ptr @jeandle.load_klass(ptr addrspace(1))
+
+define hotspotcc ptr @fold_direct() #0 gc "hotspotgc" {
+entry:
+  %obj = load ptr addrspace(1), ptr @oop_handle_Test_0
+  %klass = call hotspotcc ptr @jeandle.load_klass(ptr addrspace(1) %obj)
+  ret ptr %klass
+}
+
+; CHECK-LABEL: define hotspotcc ptr @fold_direct()
+; CHECK:       entry:
+; CHECK-NEXT:    %obj = load ptr addrspace(1), ptr @oop_handle_Test_0
+; CHECK-NEXT:    ret ptr inttoptr (i64 123456 to ptr)
+
+define hotspotcc ptr @fold_same_phi(i1 %cond) #0 gc "hotspotgc" {
+entry:
+  %obj = load ptr addrspace(1), ptr @oop_handle_Test_0
+  br i1 %cond, label %left, label %right
+
+left:
+  br label %merge
+
+right:
+  br label %merge
+
+merge:
+  %merged = phi ptr addrspace(1) [ %obj, %left ], [ %obj, %right ]
+  %klass = call hotspotcc ptr @jeandle.load_klass(ptr addrspace(1) %merged)
+  ret ptr %klass
+}
+
+; CHECK-LABEL: define hotspotcc ptr @fold_same_phi(
+; CHECK:       merge:
+; CHECK-NEXT:    %merged = phi ptr addrspace(1)
+; CHECK-NEXT:    ret ptr inttoptr (i64 123456 to ptr)
+
+define hotspotcc ptr @keep_dynamic(ptr addrspace(1) %obj) #0 gc "hotspotgc" {
+entry:
+  %klass = call hotspotcc ptr @jeandle.load_klass(ptr addrspace(1) %obj)
+  ret ptr %klass
+}
+
+; CHECK-LABEL: define hotspotcc ptr @keep_dynamic(
+; CHECK:         %klass = call hotspotcc ptr @jeandle.load_klass(ptr addrspace(1) %obj)
+; CHECK-NEXT:    ret ptr %klass
+
+define hotspotcc ptr @keep_unavailable() #0 gc "hotspotgc" {
+entry:
+  %obj = load ptr addrspace(1), ptr @oop_handle_Test_1
+  %klass = call hotspotcc ptr @jeandle.load_klass(ptr addrspace(1) %obj)
+  ret ptr %klass
+}
+
+; CHECK-LABEL: define hotspotcc ptr @keep_unavailable()
+; CHECK:         %klass = call hotspotcc ptr @jeandle.load_klass(ptr addrspace(1) %obj)
+; CHECK-NEXT:    ret ptr %klass
+
+attributes #0 = { "java-method"="1" }
+
+!java-method-compilation = !{}

--- a/llvm/test/Jeandle/constant-field-folding/load-klass.ll
+++ b/llvm/test/Jeandle/constant-field-folding/load-klass.ll
@@ -60,6 +60,39 @@ entry:
 ; CHECK:         %klass = call hotspotcc ptr @jeandle.load_klass(ptr addrspace(1) %obj)
 ; CHECK-NEXT:    ret ptr %klass
 
+define hotspotcc ptr @fold_exact_type(
+    ptr addrspace(1) nonnull "java-klass"="123456"
+      "java-klass-exact" %obj) #0 gc "hotspotgc" {
+entry:
+  %klass = call hotspotcc ptr @jeandle.load_klass(ptr addrspace(1) %obj)
+  ret ptr %klass
+}
+
+define hotspotcc ptr @keep_nonexact_type(
+    ptr addrspace(1) nonnull "java-klass"="123456" %obj)
+    #0 gc "hotspotgc" {
+entry:
+  %klass = call hotspotcc ptr @jeandle.load_klass(ptr addrspace(1) %obj)
+  ret ptr %klass
+}
+
+define hotspotcc ptr @keep_nullable_exact_type(
+    ptr addrspace(1) "java-klass"="123456" "java-klass-exact" %obj)
+    #0 gc "hotspotgc" {
+entry:
+  %klass = call hotspotcc ptr @jeandle.load_klass(ptr addrspace(1) %obj)
+  ret ptr %klass
+}
+
+; CHECK-LABEL: define hotspotcc ptr @fold_exact_type(
+; CHECK:       ret ptr inttoptr (i64 123456 to ptr)
+
+; CHECK-LABEL: define hotspotcc ptr @keep_nonexact_type(
+; CHECK:         %klass = call hotspotcc ptr @jeandle.load_klass(ptr addrspace(1) %obj)
+
+; CHECK-LABEL: define hotspotcc ptr @keep_nullable_exact_type(
+; CHECK:         %klass = call hotspotcc ptr @jeandle.load_klass(ptr addrspace(1) %obj)
+
 attributes #0 = { "java-method"="1" }
 
 !java-method-compilation = !{}

--- a/llvm/test/Jeandle/constant-field-folding/load-mirror-klass.ll
+++ b/llvm/test/Jeandle/constant-field-folding/load-mirror-klass.ll
@@ -1,0 +1,56 @@
+; RUN: opt -S -passes="constant-field-folding" -jeandle-vm-callback-log=%S/Inputs/load-mirror-klass.cblog %s 2>&1 | FileCheck %s
+
+@oop_handle_ClassMirror_0 = external dso_local global ptr addrspace(1)
+@oop_handle_PrimitiveMirror_1 = external dso_local global ptr addrspace(1)
+@oop_handle_Unknown_2 = external dso_local global ptr addrspace(1)
+
+declare hotspotcc ptr @jeandle.load_mirror_klass(ptr addrspace(1))
+
+define hotspotcc ptr @fold_reference_mirror() #0 gc "hotspotgc" {
+entry:
+  %mirror = load ptr addrspace(1), ptr @oop_handle_ClassMirror_0
+  %klass = call hotspotcc ptr @jeandle.load_mirror_klass(ptr addrspace(1) %mirror)
+  ret ptr %klass
+}
+
+; CHECK-LABEL: define hotspotcc ptr @fold_reference_mirror()
+; CHECK:       entry:
+; CHECK-NEXT:    %mirror = load ptr addrspace(1), ptr @oop_handle_ClassMirror_0
+; CHECK-NEXT:    ret ptr inttoptr (i64 234567 to ptr)
+
+define hotspotcc ptr @keep_dynamic(ptr addrspace(1) %mirror) #0 gc "hotspotgc" {
+entry:
+  %klass = call hotspotcc ptr @jeandle.load_mirror_klass(ptr addrspace(1) %mirror)
+  ret ptr %klass
+}
+
+; CHECK-LABEL: define hotspotcc ptr @keep_dynamic(
+; CHECK:         %klass = call hotspotcc ptr @jeandle.load_mirror_klass(ptr addrspace(1) %mirror)
+; CHECK-NEXT:    ret ptr %klass
+
+define hotspotcc ptr @fold_primitive_mirror_to_null() #0 gc "hotspotgc" {
+entry:
+  %mirror = load ptr addrspace(1), ptr @oop_handle_PrimitiveMirror_1
+  %klass = call hotspotcc ptr @jeandle.load_mirror_klass(ptr addrspace(1) %mirror)
+  ret ptr %klass
+}
+
+; CHECK-LABEL: define hotspotcc ptr @fold_primitive_mirror_to_null()
+; CHECK:       entry:
+; CHECK-NEXT:    %mirror = load ptr addrspace(1), ptr @oop_handle_PrimitiveMirror_1
+; CHECK-NEXT:    ret ptr null
+
+define hotspotcc ptr @keep_non_mirror_or_unavailable() #0 gc "hotspotgc" {
+entry:
+  %mirror = load ptr addrspace(1), ptr @oop_handle_Unknown_2
+  %klass = call hotspotcc ptr @jeandle.load_mirror_klass(ptr addrspace(1) %mirror)
+  ret ptr %klass
+}
+
+; CHECK-LABEL: define hotspotcc ptr @keep_non_mirror_or_unavailable()
+; CHECK:         %klass = call hotspotcc ptr @jeandle.load_mirror_klass(ptr addrspace(1) %mirror)
+; CHECK-NEXT:    ret ptr %klass
+
+attributes #0 = { "java-method"="1" }
+
+!java-method-compilation = !{}

--- a/llvm/test/Jeandle/constant-field-folding/mirror-klass-initialized-chain.ll
+++ b/llvm/test/Jeandle/constant-field-folding/mirror-klass-initialized-chain.ll
@@ -1,0 +1,23 @@
+; RUN: opt -S -passes="constant-field-folding" -jeandle-vm-callback-log=%S/Inputs/mirror-klass-initialized-chain.cblog %s 2>&1 | FileCheck %s
+
+@oop_handle_Class_0 = external global ptr addrspace(1)
+
+declare hotspotcc ptr @jeandle.load_mirror_klass(ptr addrspace(1))
+declare hotspotcc i1 @jeandle.klass_is_initialized(ptr)
+
+define hotspotcc i1 @fold_mirror_klass_initialized() #0 gc "hotspotgc" {
+entry:
+  %mirror = load ptr addrspace(1), ptr @oop_handle_Class_0
+  %klass = call hotspotcc ptr @jeandle.load_mirror_klass(ptr addrspace(1) %mirror)
+  %initialized = call hotspotcc i1 @jeandle.klass_is_initialized(ptr %klass)
+  ret i1 %initialized
+}
+
+; CHECK-LABEL: define hotspotcc i1 @fold_mirror_klass_initialized()
+; CHECK:       entry:
+; CHECK-NEXT:    %mirror = load ptr addrspace(1), ptr @oop_handle_Class_0
+; CHECK-NEXT:    ret i1 true
+
+attributes #0 = { "java-method"="1" }
+
+!java-method-compilation = !{}

--- a/llvm/test/Jeandle/constant-field-folding/mirror-klass-layout-chain.ll
+++ b/llvm/test/Jeandle/constant-field-folding/mirror-klass-layout-chain.ll
@@ -1,0 +1,25 @@
+; RUN: opt -S -passes="constant-field-folding" -jeandle-vm-callback-log=%S/Inputs/mirror-klass-layout-chain.cblog %s 2>&1 | FileCheck %s
+
+@oop_handle_CallSite_0 = external dso_local global ptr addrspace(1)
+
+declare hotspotcc ptr @jeandle.load_mirror_klass(ptr addrspace(1))
+declare hotspotcc i32 @jeandle.layout_helper(ptr)
+
+define hotspotcc i32 @fold_constant_field_mirror_layout_chain() #0 gc "hotspotgc" {
+entry:
+  %callsite = load ptr addrspace(1), ptr @oop_handle_CallSite_0
+  %mirror.addr = getelementptr i8, ptr addrspace(1) %callsite, i64 16
+  %mirror = load ptr addrspace(1), ptr addrspace(1) %mirror.addr
+  %klass = call hotspotcc ptr @jeandle.load_mirror_klass(ptr addrspace(1) %mirror)
+  %layout = call hotspotcc i32 @jeandle.layout_helper(ptr %klass)
+  ret i32 %layout
+}
+
+; CHECK:       @oop_handle_ClassMirror_1 = external dso_local global ptr addrspace(1)
+; CHECK-LABEL: define hotspotcc i32 @fold_constant_field_mirror_layout_chain()
+; CHECK:         %folded.oop = load ptr addrspace(1), ptr @oop_handle_ClassMirror_1
+; CHECK-NEXT:    ret i32 -2147483637
+
+attributes #0 = { "java-method"="1" }
+
+!java-method-compilation = !{}

--- a/llvm/test/Jeandle/partial-escape/452_get_class_array_types.ll
+++ b/llvm/test/Jeandle/partial-escape/452_get_class_array_types.ll
@@ -1,0 +1,60 @@
+; RUN: opt -S -passes="require<partial-escape-analysis>,partial-escape-transform" \
+; RUN:   -jeandle-vm-callback-log=%S/Inputs/452_get_class_array_types.cblog \
+; RUN:   %s | FileCheck %s
+
+; PEA getClass coverage for virtual arrays.  The exact array Klass is known at
+; the allocation site, so get_class can be replaced with the corresponding
+; java.lang.Class mirror without materializing either array.  Keep primitive
+; and object arrays separate: their Klass values must select different mirror
+; oop handles (this is the part that the Java regression tests exercise).
+
+declare hotspotcc ptr addrspace(1) @jeandle.new_array(ptr, i32, i32, i32, i32)
+declare hotspotcc ptr addrspace(1) @jeandle.get_class(ptr addrspace(1))
+declare i32 @__gxx_personality_v0(...)
+
+define ptr addrspace(1) @test_get_class_primitive_array()
+    gc "hotspotgc" personality ptr @__gxx_personality_v0 {
+entry:
+  %arr = invoke hotspotcc ptr addrspace(1) @jeandle.new_array(
+      ptr inttoptr (i64 7001 to ptr), i32 4, i32 32, i32 16, i32 1048576)
+      to label %body unwind label %unwind
+body:
+  %klass = call hotspotcc ptr addrspace(1)
+      @jeandle.get_class(ptr addrspace(1) %arr)
+  ret ptr addrspace(1) %klass
+unwind:
+  %lp = landingpad i64 cleanup
+  resume i64 %lp
+}
+
+define ptr addrspace(1) @test_get_class_object_array()
+    gc "hotspotgc" personality ptr @__gxx_personality_v0 {
+entry:
+  %arr = invoke hotspotcc ptr addrspace(1) @jeandle.new_array(
+      ptr inttoptr (i64 7002 to ptr), i32 4, i32 64, i32 16, i32 1048576)
+      to label %body unwind label %unwind
+body:
+  %klass = call hotspotcc ptr addrspace(1)
+      @jeandle.get_class(ptr addrspace(1) %arr)
+  ret ptr addrspace(1) %klass
+unwind:
+  %lp = landingpad i64 cleanup
+  resume i64 %lp
+}
+
+; The primitive array selects its own mirror handle and its allocation is gone.
+; CHECK-LABEL: define ptr addrspace(1) @test_get_class_primitive_array
+; CHECK-NOT: jeandle.new_array
+; CHECK-NOT: jeandle.get_class
+; CHECK: load ptr addrspace(1), ptr @oop_handle_PrimitiveArray_10
+; CHECK: ret ptr addrspace(1)
+
+; The object array likewise selects a distinct mirror handle and is not
+; materialized merely because getClass was queried.
+; CHECK-LABEL: define ptr addrspace(1) @test_get_class_object_array
+; CHECK-NOT: jeandle.new_array
+; CHECK-NOT: jeandle.get_class
+; CHECK: load ptr addrspace(1), ptr @oop_handle_ObjectArray_11
+; CHECK: ret ptr addrspace(1)
+
+!java-method-compilation = !{}

--- a/llvm/test/Jeandle/partial-escape/453_get_class_after_publish.ll
+++ b/llvm/test/Jeandle/partial-escape/453_get_class_after_publish.ll
@@ -1,0 +1,38 @@
+; RUN: opt -S -passes="require<partial-escape-analysis>,partial-escape-transform" \
+; RUN:   -jeandle-vm-callback-log=%S/Inputs/453_get_class_after_publish.cblog \
+; RUN:   %s | FileCheck %s
+
+; A receiver allocated in this function starts virtual, but publishing it
+; materializes it before get_class.  The allocation and publish must remain for
+; correctness.  In the PEA-only pipeline, get_class currently remains as well
+; because foldGetClass handles virtual receivers; this is a capability-boundary
+; check, not a permanent restriction on CFF/type folding.
+
+declare hotspotcc ptr addrspace(1) @jeandle.new_instance(ptr, i32)
+declare hotspotcc ptr addrspace(1) @jeandle.get_class(ptr addrspace(1))
+declare void @publish(ptr addrspace(1))
+declare i32 @__gxx_personality_v0(...)
+
+define ptr addrspace(1) @test_get_class_after_publish()
+    gc "hotspotgc" personality ptr @__gxx_personality_v0 {
+entry:
+  %o = invoke hotspotcc ptr addrspace(1) @jeandle.new_instance(
+      ptr inttoptr (i64 8 to ptr), i32 16)
+      to label %body unwind label %unwind
+body:
+  call void @publish(ptr addrspace(1) %o)
+  %c = call hotspotcc ptr addrspace(1)
+      @jeandle.get_class(ptr addrspace(1) %o)
+  ret ptr addrspace(1) %c
+unwind:
+  %lp = landingpad i64 cleanup
+  resume i64 %lp
+}
+
+; CHECK-LABEL: define ptr addrspace(1) @test_get_class_after_publish
+; CHECK: %[[OBJ:[A-Za-z0-9._]+]] = invoke hotspotcc ptr addrspace(1) @jeandle.new_instance
+; CHECK: call void @publish(ptr addrspace(1) %[[OBJ]])
+; CHECK: call hotspotcc ptr addrspace(1) @jeandle.get_class(ptr addrspace(1) %[[OBJ]])
+; CHECK: ret ptr addrspace(1)
+
+!java-method-compilation = !{}

--- a/llvm/test/Jeandle/partial-escape/454_new_instance_initial_slow_test.ll
+++ b/llvm/test/Jeandle/partial-escape/454_new_instance_initial_slow_test.ll
@@ -1,0 +1,65 @@
+; RUN: opt -S -passes="require<partial-escape-analysis>,partial-escape-transform" \
+; RUN:   %s | FileCheck %s
+
+; The third new_instance operand is not merely a performance hint. When true,
+; the allocation must enter the runtime, which may initialize the class or
+; reject an interface/abstract Klass with InstantiationException. PEA may
+; virtualize only when this operand is proven false.
+
+declare hotspotcc ptr addrspace(1) @jeandle.new_instance(ptr, i32, i1)
+declare i32 @__gxx_personality_v0(...)
+
+define void @constant_false_is_virtualizable()
+    gc "hotspotgc" personality ptr @__gxx_personality_v0 {
+entry:
+  %o = invoke hotspotcc ptr addrspace(1) @jeandle.new_instance(
+      ptr inttoptr (i64 45401 to ptr), i32 16, i1 false)
+      to label %normal unwind label %unwind
+normal:
+  ret void
+unwind:
+  %lp = landingpad i64 cleanup
+  resume i64 %lp
+}
+
+; CHECK-LABEL: define void @constant_false_is_virtualizable
+; CHECK-NOT: jeandle.new_instance
+; CHECK: ret void
+
+define void @constant_true_keeps_runtime_semantics()
+    gc "hotspotgc" personality ptr @__gxx_personality_v0 {
+entry:
+  %o = invoke hotspotcc ptr addrspace(1) @jeandle.new_instance(
+      ptr inttoptr (i64 45402 to ptr), i32 16, i1 true)
+      to label %normal unwind label %unwind
+normal:
+  ret void
+unwind:
+  %lp = landingpad i64 cleanup
+  resume i64 %lp
+}
+
+; CHECK-LABEL: define void @constant_true_keeps_runtime_semantics
+; CHECK: invoke hotspotcc ptr addrspace(1) @jeandle.new_instance(
+; CHECK-SAME: ptr inttoptr (i64 45402 to ptr), i32 16, i1 true)
+; CHECK: to label %normal unwind label %unwind
+
+define void @dynamic_test_keeps_runtime_semantics(i1 %initial_slow_test)
+    gc "hotspotgc" personality ptr @__gxx_personality_v0 {
+entry:
+  %o = invoke hotspotcc ptr addrspace(1) @jeandle.new_instance(
+      ptr inttoptr (i64 45403 to ptr), i32 16, i1 %initial_slow_test)
+      to label %normal unwind label %unwind
+normal:
+  ret void
+unwind:
+  %lp = landingpad i64 cleanup
+  resume i64 %lp
+}
+
+; CHECK-LABEL: define void @dynamic_test_keeps_runtime_semantics
+; CHECK: invoke hotspotcc ptr addrspace(1) @jeandle.new_instance(
+; CHECK-SAME: ptr inttoptr (i64 45403 to ptr), i32 16, i1 %initial_slow_test)
+; CHECK: to label %normal unwind label %unwind
+
+!java-method-compilation = !{}

--- a/llvm/test/Jeandle/partial-escape/Inputs/452_get_class_array_types.cblog
+++ b/llvm/test/Jeandle/partial-escape/Inputs/452_get_class_array_types.cblog
@@ -1,0 +1,11 @@
+RequiresStrictLockOrder = 1
+
+# Array element metadata is queried while registering each virtual array.
+ElementBasicTypeOfArrayKlass 7001 = 4
+ElementBasicTypeOfArrayKlass 7002 = 8
+
+# Distinct array Klass values must map to distinct Class mirror oop ids.
+GetJavaMirror 7001 = 10
+GetOopHandleName 10 = "oop_handle_PrimitiveArray_10"
+GetJavaMirror 7002 = 11
+GetOopHandleName 11 = "oop_handle_ObjectArray_11"

--- a/llvm/test/Jeandle/partial-escape/Inputs/453_get_class_after_publish.cblog
+++ b/llvm/test/Jeandle/partial-escape/Inputs/453_get_class_after_publish.cblog
@@ -1,0 +1,11 @@
+RequiresStrictLockOrder = 1
+
+HasFinalizer 8 = false
+CanVirtualize 8 = true
+IsBoxed 8 = 9
+
+# Deliberately make Klass 8 foldable while virtual. This PEA-only test records
+# the current boundary: after @publish materializes the receiver, foldGetClass
+# no longer folds it. Future CFF or exact-type folding may remove the call.
+GetJavaMirror 8 = 12
+GetOopHandleName 12 = "oop_handle_Published_12"

--- a/llvm/test/Jeandle/repeated-constant-field-folding/Inputs/initialized-guard-unlocks-allocation.cblog
+++ b/llvm/test/Jeandle/repeated-constant-field-folding/Inputs/initialized-guard-unlocks-allocation.cblog
@@ -1,0 +1,1 @@
+IsKlassInitialized 123456 = true

--- a/llvm/test/Jeandle/repeated-constant-field-folding/initialized-guard-unlocks-allocation.ll
+++ b/llvm/test/Jeandle/repeated-constant-field-folding/initialized-guard-unlocks-allocation.ll
@@ -1,0 +1,25 @@
+; RUN: opt -S -passes="repeated-constant-field-folding" -jeandle-vm-callback-log=%S/Inputs/initialized-guard-unlocks-allocation.cblog %s 2>&1 | FileCheck %s
+
+; Model the Unsafe.allocateInstance shape: an initialization guard contributes
+; to the initial slow test passed into the allocation JavaOp. Proving the
+; constant Klass initialized must make that contribution false.
+
+declare hotspotcc i1 @jeandle.klass_is_initialized(ptr)
+declare ptr addrspace(1) @jeandle.new_instance(ptr, i32, i1)
+
+define ptr addrspace(1) @test() #0 gc "hotspotgc" {
+entry:
+  %initialized = call hotspotcc i1 @jeandle.klass_is_initialized(ptr inttoptr (i64 123456 to ptr))
+  %needs.initialization = xor i1 %initialized, true
+  %obj = call ptr addrspace(1) @jeandle.new_instance(ptr inttoptr (i64 123456 to ptr), i32 24, i1 %needs.initialization)
+  ret ptr addrspace(1) %obj
+}
+
+; CHECK-LABEL: define ptr addrspace(1) @test()
+; CHECK-NOT:     klass_is_initialized
+; CHECK:         %obj = call ptr addrspace(1) @jeandle.new_instance(ptr inttoptr (i64 123456 to ptr), i32 24, i1 false)
+; CHECK-NEXT:    ret ptr addrspace(1) %obj
+
+attributes #0 = { "java-method"="1" }
+
+!java-method-compilation = !{}


### PR DESCRIPTION
## Related issue(s):

issue https://github.com/jeandle/jeandle-jdk/issues/574

## What this PR does / why we need it:
Enhances LLVM constant field folding to resolve:

  - Constant oop to Klass
  - Constant Class mirror to Klass
  - Constant Klass to layout_helper

  This enables further constant propagation and downstream optimizations that depend on precise HotSpot type metadata.