### PR TITLE
fix: preserve header-entry safepoints during strip mining

### DIFF
--- a/llvm/include/llvm/Transforms/Jeandle/SafepointUtils.h
+++ b/llvm/include/llvm/Transforms/Jeandle/SafepointUtils.h
@@ -97,13 +97,14 @@ void analyzeLoop(Loop &L, LoopInfo &LI, DominatorTree &DT,
 CallInst *findKeepOne(Loop &L, LoopInfo &LI, DominatorTree &DT,
                       const RequiredPolls &Required);
 
-// A safepoint poll that SafepointStripMining relocated onto the outer
-// back-edge of a strip-mined nest: a jeandle.safepoint_poll call carrying the
+// A safepoint poll that SafepointStripMining relocated to an outer iteration
+// boundary of a strip-mined nest: a jeandle.safepoint_poll call carrying the
 // jeandle.strip-mined-poll call-site attribute.
 bool isStripMinedPoll(const Instruction &I);
 
 // A loop is the poll-free, batch-bounded inner of a strip-mined nest iff its
-// parent loop's latch holds a strip-mined poll (isStripMinedPoll). The marker
+// parent loop's latch or its per-batch inner preheader holds a strip-mined
+// poll (isStripMinedPoll). The marker
 // travels with the relocated poll, so it cannot outlive the coverage it
 // certifies. Callers are the passes adjacent to SafepointStripMining in the
 // pipeline (after-strip-mining deletion and the coverage verifier), which

--- a/llvm/lib/Transforms/Jeandle/SafepointStripMining.cpp
+++ b/llvm/lib/Transforms/Jeandle/SafepointStripMining.cpp
@@ -294,7 +294,7 @@ std::optional<StripMineShape> checkStripMineShape(Loop *L, const IVInfo &IV,
   bool FirstIterationGuaranteed =
       SE.isLoopEntryGuardedByCond(L, ContinuePred, Start, Limit) ||
       SE.isKnownPredicate(ContinuePred, SE.applyLoopGuards(Start, L),
-                           SE.applyLoopGuards(Limit, L));
+                          SE.applyLoopGuards(Limit, L));
   // NE is equivalent to the normalized relational predicate only when the
   // entry order and unit step prove that the IV reaches the limit without
   // passing it. A post-tested skeleton preserves the mandatory first
@@ -415,10 +415,11 @@ bool isHeaderEntryPoll(CallInst *P, BasicBlock *Header) {
 // header phi is normally current-iteration state, even when it also happens to
 // be the latch input of another copy/swap recurrence. An invariant self
 // recurrence is safe; a header-entry poll is also supported by relocating it
-// to the batch entry rather than its latch. Other operands must be loop-invariant,
-// a latch-carried next value, or a pure cast chain rooted at such a next value.
-// The returned plans are consumed verbatim during relocation, keeping the
-// eligibility proof and materialization behavior in sync.
+// to the batch entry rather than its latch. Other operands must be
+// loop-invariant, a latch-carried next value, or a pure cast chain rooted at
+// such a next value. The returned plans are consumed verbatim during
+// relocation, keeping the eligibility proof and materialization behavior in
+// sync.
 std::optional<SmallVector<DeoptBoundaryValue, 8>>
 analyzeDeoptBoundaryValues(CallInst *P, Loop *L, BasicBlock *Header,
                            BasicBlock *Latch) {
@@ -839,10 +840,10 @@ buildStripMinePlanWithIV(Loop *L, const IVInfo &IV, ICmpInst *ExitCmp,
     HeaderPhis.push_back({&Phi, Phi.getIncomingValueForBlock(Shape.Preheader),
                           Phi.getIncomingValueForBlock(Shape.Latch)});
 
-  bool PollAtEntry = llvm::any_of(*DeoptBoundaryValues,
-                                 [](const DeoptBoundaryValue &V) {
-                                   return V.EntryPhi != nullptr;
-                                 });
+  bool PollAtEntry =
+      llvm::any_of(*DeoptBoundaryValues, [](const DeoptBoundaryValue &V) {
+        return V.EntryPhi != nullptr;
+      });
   return StripMinePlan{L,
                        Shape,
                        IV.Phi,
@@ -1287,15 +1288,15 @@ static Loop *reparentAsOuterLoop(Loop *L, BasicBlock *OuterPH,
 // Relocate the poll to the matching outer iteration boundary, immediately
 // before OuterBr: clone it with the deopt operands remapped to the outer
 // recurrences, and tag the clone as the strip-mined poll. Entry-state phis
-// map by identity to the current outer phis at the batch entry. Latch-carried next
-// values are remapped to the outer PHIs; optimizer-introduced cast chains are
-// rebuilt from those outer values and cached in Remap. A loop-invariant latch
-// value (e.g. a phi whose latch operand is a constant) is skipped: it needs no
-// remap, and keying Remap on it would spuriously rewrite an unrelated but equal
-// constant elsewhere in the deopt bundle. The bci/frame layout in the deopt
-// bundle is carried over verbatim — no LLVM pass may synthesize a poll, only
-// relocate one. The strip-mined-poll attribute is the contract the coverage
-// verifier trusts without re-deriving the bound, and the marker the
+// map by identity to the current outer phis at the batch entry. Latch-carried
+// next values are remapped to the outer PHIs; optimizer-introduced cast chains
+// are rebuilt from those outer values and cached in Remap. A loop-invariant
+// latch value (e.g. a phi whose latch operand is a constant) is skipped: it
+// needs no remap, and keying Remap on it would spuriously rewrite an unrelated
+// but equal constant elsewhere in the deopt bundle. The bci/frame layout in the
+// deopt bundle is carried over verbatim — no LLVM pass may synthesize a poll,
+// only relocate one. The strip-mined-poll attribute is the contract the
+// coverage verifier trusts without re-deriving the bound, and the marker the
 // after-strip-mining poll elimination keys on; marking the poll itself means
 // the marker cannot outlive the coverage it certifies.
 static void relocatePollToOuterBoundary(StripMinePlan &Plan, Value *OuterIV,

--- a/llvm/lib/Transforms/Jeandle/SafepointStripMining.cpp
+++ b/llvm/lib/Transforms/Jeandle/SafepointStripMining.cpp
@@ -288,8 +288,13 @@ std::optional<StripMineShape> checkStripMineShape(Loop *L, const IVInfo &IV,
 
   const SCEV *Start = IV.AR->getStart();
   const SCEV *Limit = SE.getSCEV(ExitCmp->getOperand(LimitIdx));
+  // Widening an inclusive int loop can produce a != zext(limit + 1)
+  // exit. Refine the expression using its dominating guards as well as
+  // querying direct implication, without assuming the != exit is reachable.
   bool FirstIterationGuaranteed =
-      SE.isLoopEntryGuardedByCond(L, ContinuePred, Start, Limit);
+      SE.isLoopEntryGuardedByCond(L, ContinuePred, Start, Limit) ||
+      SE.isKnownPredicate(ContinuePred, SE.applyLoopGuards(Start, L),
+                           SE.applyLoopGuards(Limit, L));
   // NE is equivalent to the normalized relational predicate only when the
   // entry order and unit step prove that the IV reaches the limit without
   // passing it. A post-tested skeleton preserves the mandatory first
@@ -384,12 +389,33 @@ struct DeoptBoundaryValue {
   // Outermost-to-innermost casts from Original down to OriginalRoot. Applying
   // the plan walks this list in reverse and memoizes each rebuilt cast.
   SmallVector<CastInst *, 2> Casts;
+  // An entry poll is relocated to the next batch's entry, using this exact
+  // recurrence's outer phi (not a recurrence with the same latch operand).
+  PHINode *EntryPhi = nullptr;
 };
+
+// Splitting a conditional backedge through a poll block can make LoopRotate
+// choose that block as the header. Its poll then observes entry state rather
+// than latch state. Restrict this case to a poll preceded only by phis and
+// casts: a poll after an increment or other body instruction can mix current
+// and next state and must continue to use the conservative latch-state gate.
+bool isHeaderEntryPoll(CallInst *P, BasicBlock *Header) {
+  if (P->getParent() != Header)
+    return false;
+  for (Instruction &I : *Header) {
+    if (&I == P)
+      return true;
+    if (!isa<PHINode, CastInst>(I) && !I.isDebugOrPseudoInst())
+      return false;
+  }
+  return false;
+}
 
 // The relocated poll represents the next iteration at a batch boundary. A raw
 // header phi is normally current-iteration state, even when it also happens to
-// be the latch input of another copy/swap recurrence. The one safe exception is
-// an invariant self recurrence. Other operands must either be loop-invariant,
+// be the latch input of another copy/swap recurrence. An invariant self
+// recurrence is safe; a header-entry poll is also supported by relocating it
+// to the batch entry rather than its latch. Other operands must be loop-invariant,
 // a latch-carried next value, or a pure cast chain rooted at such a next value.
 // The returned plans are consumed verbatim during relocation, keeping the
 // eligibility proof and materialization behavior in sync.
@@ -400,6 +426,7 @@ analyzeDeoptBoundaryValues(CallInst *P, Loop *L, BasicBlock *Header,
   auto OB = P->getOperandBundle(LLVMContext::OB_deopt);
   if (!OB)
     return Plans;
+  bool EntryPoll = isHeaderEntryPoll(P, Header);
   for (const Use &U : OB->Inputs) {
     Value *V = U.get();
     if (L->isLoopInvariant(V)) {
@@ -410,6 +437,11 @@ analyzeDeoptBoundaryValues(CallInst *P, Loop *L, BasicBlock *Header,
       if (Value *Initial =
               getLoopInvariantSelfRecurrenceInitial(Phi, L, Header, Latch)) {
         Plans.push_back({V, V, Initial, nullptr, {}});
+        continue;
+      }
+      if (EntryPoll) {
+        Plans.push_back(
+            {V, V, Phi, Phi->getIncomingValueForBlock(Latch), {}, Phi});
         continue;
       }
       return std::nullopt;
@@ -430,6 +462,11 @@ analyzeDeoptBoundaryValues(CallInst *P, Loop *L, BasicBlock *Header,
       if (Value *Initial =
               getLoopInvariantSelfRecurrenceInitial(Phi, L, Header, Latch)) {
         Plans.push_back({V, Root, Initial, nullptr, std::move(Casts)});
+        continue;
+      }
+      if (EntryPoll) {
+        Plans.push_back({V, Root, Phi, Phi->getIncomingValueForBlock(Latch),
+                         std::move(Casts), Phi});
         continue;
       }
       return std::nullopt;
@@ -555,6 +592,7 @@ struct StripMinePlan {
   uint64_t ChunkIters;
   Value *InitVal;
   Value *Limit;
+  bool PollAtEntry;
 
   /// Pre-condition re-check queued before applying: this plan still matches the
   /// IR (loop/header/latch/exiting/exit identity, exit-branch wiring, poll
@@ -801,6 +839,10 @@ buildStripMinePlanWithIV(Loop *L, const IVInfo &IV, ICmpInst *ExitCmp,
     HeaderPhis.push_back({&Phi, Phi.getIncomingValueForBlock(Shape.Preheader),
                           Phi.getIncomingValueForBlock(Shape.Latch)});
 
+  bool PollAtEntry = llvm::any_of(*DeoptBoundaryValues,
+                                 [](const DeoptBoundaryValue &V) {
+                                   return V.EntryPhi != nullptr;
+                                 });
   return StripMinePlan{L,
                        Shape,
                        IV.Phi,
@@ -816,7 +858,8 @@ buildStripMinePlanWithIV(Loop *L, const IVInfo &IV, ICmpInst *ExitCmp,
                        IsSigned,
                        N,
                        InitVal,
-                       Limit};
+                       Limit,
+                       PollAtEntry};
 }
 
 std::optional<StripMinePlan>
@@ -917,7 +960,8 @@ bool StripMinePlan::stillStructurallyValid(LoopInfo &LI,
     return false;
   if (!jeandle::isSafepointPoll(*PollToMove) || !PollToMove->getParent() ||
       LI.getLoopFor(PollToMove->getParent()) != L ||
-      !DT.dominates(PollToMove->getParent(), Shape.Latch))
+      !DT.dominates(PollToMove->getParent(), Shape.Latch) ||
+      (PollAtEntry && !isHeaderEntryPoll(PollToMove, Shape.Header)))
     return false;
   if (ExitCmp->getParent() != Shape.ExitingBB || !ExitCmp->hasOneUse() ||
       ExitCmp->getOperand(Shape.LimitOperandIdx) != Limit ||
@@ -968,7 +1012,7 @@ bool StripMinePlan::stillStructurallyValid(LoopInfo &LI,
         return false;
       const DeoptBoundaryValue &Boundary = DeoptBoundaryValues[I];
       if (!Boundary.OriginalRoot) {
-        if (Boundary.BoundaryBase || Boundary.LatchValue ||
+        if (Boundary.BoundaryBase || Boundary.LatchValue || Boundary.EntryPhi ||
             !Boundary.Casts.empty())
           return false;
         continue;
@@ -981,6 +1025,15 @@ bool StripMinePlan::stillStructurallyValid(LoopInfo &LI,
       }
       if (Root != Boundary.OriginalRoot)
         return false;
+      if (Boundary.EntryPhi) {
+        if (!isHeaderEntryPoll(PollToMove, Shape.Header) ||
+            Root != Boundary.EntryPhi || Root != Boundary.BoundaryBase ||
+            Boundary.EntryPhi->getParent() != Shape.Header ||
+            Boundary.EntryPhi->getIncomingValueForBlock(Shape.Latch) !=
+                Boundary.LatchValue)
+          return false;
+        continue;
+      }
       if (Boundary.LatchValue) {
         if (Boundary.BoundaryBase != Boundary.LatchValue ||
             Root != Boundary.LatchValue ||
@@ -1231,9 +1284,10 @@ static Loop *reparentAsOuterLoop(Loop *L, BasicBlock *OuterPH,
   return OuterL;
 }
 
-// Relocate the planned back-edge poll onto the outer back-edge, immediately
+// Relocate the poll to the matching outer iteration boundary, immediately
 // before OuterBr: clone it with the deopt operands remapped to the outer
-// recurrences, and tag the clone as the strip-mined poll. Latch-carried next
+// recurrences, and tag the clone as the strip-mined poll. Entry-state phis
+// map by identity to the current outer phis at the batch entry. Latch-carried next
 // values are remapped to the outer PHIs; optimizer-introduced cast chains are
 // rebuilt from those outer values and cached in Remap. A loop-invariant latch
 // value (e.g. a phi whose latch operand is a constant) is skipped: it needs no
@@ -1244,23 +1298,27 @@ static Loop *reparentAsOuterLoop(Loop *L, BasicBlock *OuterPH,
 // verifier trusts without re-deriving the bound, and the marker the
 // after-strip-mining poll elimination keys on; marking the poll itself means
 // the marker cannot outlive the coverage it certifies.
-static void relocatePollToOuterLatch(StripMinePlan &Plan, Value *OuterIVNext,
-                                     ArrayRef<PHINode *> OuterReducNext,
-                                     BranchInst *OuterBr) {
+static void relocatePollToOuterBoundary(StripMinePlan &Plan, Value *OuterIV,
+                                        ArrayRef<PHINode *> OuterReducs,
+                                        BranchInst *OuterBr) {
   Loop *L = Plan.L;
   const StripMineShape &Shape = Plan.Shape;
   CallInst *PollToMove = Plan.PollToMove;
   ArrayRef<PHINode *> LiftedHeaderPhis = Plan.LiftedHeaderPhis;
 
   DenseMap<Value *, Value *> Remap;
+  DenseMap<PHINode *, Value *> EntryRemap;
+  EntryRemap[Plan.IVPhi] = OuterIV;
   auto addRemap = [&](Value *LatchVal, Value *Outer) {
     if (!L->isLoopInvariant(LatchVal))
       Remap[LatchVal] = Outer;
   };
-  addRemap(Plan.IVPhi->getIncomingValueForBlock(Shape.Latch), OuterIVNext);
-  for (size_t I = 0; I < LiftedHeaderPhis.size(); ++I)
+  addRemap(Plan.IVPhi->getIncomingValueForBlock(Shape.Latch), OuterIV);
+  for (size_t I = 0; I < LiftedHeaderPhis.size(); ++I) {
     addRemap(LiftedHeaderPhis[I]->getIncomingValueForBlock(Shape.Latch),
-             OuterReducNext[I]);
+             OuterReducs[I]);
+    EntryRemap[LiftedHeaderPhis[I]] = OuterReducs[I];
+  }
   SmallVector<OperandBundleDef, 1> Bundles;
   if (auto OB = PollToMove->getOperandBundle(LLVMContext::OB_deopt)) {
     assert(OB->Inputs.size() == Plan.DeoptBoundaryValues.size() &&
@@ -1273,7 +1331,10 @@ static void relocatePollToOuterLatch(StripMinePlan &Plan, Value *OuterIVNext,
       }
 
       Value *Remapped = Boundary.BoundaryBase;
-      if (auto It = Remap.find(Boundary.BoundaryBase); It != Remap.end())
+      if (Boundary.EntryPhi) {
+        Remapped = EntryRemap.lookup(Boundary.EntryPhi);
+        assert(Remapped && "entry recurrence has no outer value");
+      } else if (auto It = Remap.find(Boundary.BoundaryBase); It != Remap.end())
         Remapped = It->second;
       else
         assert(L->isLoopInvariant(Boundary.BoundaryBase) &&
@@ -1521,11 +1582,17 @@ void applyStripMinePlan(StripMinePlan &Plan, LoopInfo &LI, DominatorTree &DT,
   rewireInnerHeaderForBatch(Plan, Frame);
   buildOuterLatch(Plan, Ty, Limit, Frame);
 
-  // Relocate the back-edge poll onto the outer back-edge (cloned, with its
-  // deopt state remapped to the outer recurrences and tagged as the
-  // strip-mined poll that certifies the inner loop's bounded coverage).
-  relocatePollToOuterLatch(Plan, Frame.OuterIVNext, Frame.OuterReducNext,
-                           Frame.OuterBr);
+  // Preserve the poll's iteration boundary. An entry poll must stay after the
+  // outer entry test: moving it to the outer latch could deopt into an extra
+  // iteration on the final exit. Its raw header phis map to the outer current
+  // recurrences, while a latch poll continues to use the outer next values.
+  if (Plan.PollAtEntry)
+    relocatePollToOuterBoundary(
+        Plan, Frame.OuterIV, Frame.OuterReducPhis,
+        cast<BranchInst>(Frame.InnerEntry->getTerminator()));
+  else
+    relocatePollToOuterBoundary(Plan, Frame.OuterIVNext, Frame.OuterReducNext,
+                                Frame.OuterBr);
 
   // Rewrite the primary-exit LCSSA PHI incomings to the outer skeleton's exit
   // boundary, using the recurrence role recorded by the plan.

--- a/llvm/lib/Transforms/Jeandle/SafepointUtils.cpp
+++ b/llvm/lib/Transforms/Jeandle/SafepointUtils.cpp
@@ -174,7 +174,14 @@ bool llvm::jeandle::isMarkedStripMinedInner(Loop &L) {
   BasicBlock *OuterLatch = Outer->getLoopLatch();
   if (!OuterLatch)
     return false;
-  return llvm::any_of(*OuterLatch, isStripMinedPoll);
+  if (llvm::any_of(*OuterLatch, isStripMinedPoll))
+    return true;
+  // A rotated entry poll is relocated to the per-batch inner preheader,
+  // after the outer entry test, rather than onto the outer backedge.
+  BasicBlock *InnerEntry = L.getLoopPreheader();
+  return InnerEntry && Outer->contains(InnerEntry) &&
+         InnerEntry->getSinglePredecessor() == Outer->getHeader() &&
+         llvm::any_of(*InnerEntry, isStripMinedPoll);
 }
 
 bool llvm::jeandle::backedgeCountProvablyLessThan(Loop &L,

--- a/llvm/test/Jeandle/SafepointElimination/strip-mine-deopt-entry-state.ll
+++ b/llvm/test/Jeandle/SafepointElimination/strip-mine-deopt-entry-state.ll
@@ -1,0 +1,128 @@
+; RUN: opt -passes='loop-simplify,lcssa,safepoint-strip-mining<strip-mining>,safepoint-poll-elimination<after-strip-mining>,verify<jeandle-safepoint-coverage>,verify' \
+; RUN:   -jeandle-loop-strip-mining-iter=8 -jeandle-verify-safepoint-coverage=fatal -S < %s | FileCheck %s
+
+; A taken-edge poll becomes a header-entry poll after loop rotation. Its Java
+; locals (including a widened IV cast back to int) represent entry state, not
+; the preceding batch's final body state. Keep the poll at the per-batch entry
+; so a final exit never deopts into an iteration which should not execute.
+declare hotspotcc void @jeandle.safepoint_poll()
+
+define i64 @entry_state(i32 noundef %limit) "java-method" {
+entry:
+  %nonempty = icmp sgt i32 %limit, 1
+  br i1 %nonempty, label %preheader, label %exit
+preheader:
+  %wide.limit = zext i32 %limit to i64
+  br label %loop
+loop:
+  %iv = phi i64 [ 1, %preheader ], [ %iv.next, %loop ]
+  %sum = phi i64 [ 0, %preheader ], [ %sum.next, %loop ]
+  %count = phi i32 [ 1, %preheader ], [ %count.next, %loop ]
+  %local = trunc nuw nsw i64 %iv to i32
+  call hotspotcc void @jeandle.safepoint_poll()
+      [ "deopt"(i32 22, i32 22, i64 %sum, i32 %count, i32 %local, i32 %limit) ]
+  %sum.next = add i64 %sum, %iv
+  %count.next = add nuw nsw i32 %count, 1
+  %iv.next = add nuw nsw i64 %iv, 1
+  %more = icmp ne i64 %iv.next, %wide.limit
+  br i1 %more, label %loop, label %exit
+exit:
+  %result = phi i64 [ 0, %entry ], [ %sum.next, %loop ]
+  ret i64 %result
+}
+
+; CHECK-LABEL: @entry_state(
+; CHECK:       loop:
+; CHECK-NOT:     call hotspotcc void @jeandle.safepoint_poll
+; CHECK:         %sum.next = add
+; CHECK:       loop.outer.inner.entry:
+; CHECK:         %local.outer = trunc nuw nsw i64 %outer.iv to i32
+; CHECK-NEXT:    call hotspotcc void @jeandle.safepoint_poll() #{{[0-9]+}}
+; CHECK-SAME:      [ "deopt"(i32 22, i32 22, i64 %sum.outer, i32 %count.outer, i32 %local.outer, i32 %limit) ]
+; CHECK-NEXT:    br label %loop
+; CHECK:       loop.outer.latch:
+; CHECK-NOT:     call hotspotcc void @jeandle.safepoint_poll
+; CHECK:       }
+
+; A swap recurrence must be remapped by phi identity. Mapping a raw entry phi
+; through the latch-value lookup would interchange a and b at a batch entry.
+define void @entry_swap(i64 noundef %limit) "java-method" {
+entry:
+  br label %loop
+loop:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
+  %a = phi i64 [ 1, %entry ], [ %b, %loop ]
+  %b = phi i64 [ 2, %entry ], [ %a, %loop ]
+  call hotspotcc void @jeandle.safepoint_poll()
+      [ "deopt"(i64 %iv, i64 %a, i64 %b) ]
+  %iv.next = add i64 %iv, 1
+  %more = icmp slt i64 %iv.next, %limit
+  br i1 %more, label %loop, label %exit
+exit:
+  ret void
+}
+
+; CHECK-LABEL: @entry_swap(
+; CHECK:       loop.outer.inner.entry:
+; CHECK:         call hotspotcc void @jeandle.safepoint_poll() #{{[0-9]+}}
+; CHECK-SAME:      [ "deopt"(i64 %outer.iv, i64 %a.outer, i64 %b.outer) ]
+; CHECK:       loop.outer.latch:
+; CHECK-NOT:     call hotspotcc void @jeandle.safepoint_poll
+; CHECK:       }
+
+; IndVarSimplify can turn i <= limit into a widened != limit+1 test.
+; Apply the dominating entry guard to that expression before proving the
+; ordered unit-stride range. A direct implication query misses this shape.
+declare i32 @llvm.smin.i32(i32, i32)
+
+define i64 @entry_inclusive(i32 noundef %limit) "java-method" {
+entry:
+  %cap = call i32 @llvm.smin.i32(i32 %limit, i32 1000000)
+  %nonempty = icmp sge i32 %cap, 1
+  br i1 %nonempty, label %preheader, label %exit
+preheader:
+  %end = add nsw i32 %cap, 1
+  %wide.limit = zext i32 %end to i64
+  br label %loop
+loop:
+  %iv = phi i64 [ 1, %preheader ], [ %iv.next, %loop ]
+  %sum = phi i64 [ 0, %preheader ], [ %sum.next, %loop ]
+  %local = trunc nuw nsw i64 %iv to i32
+  call hotspotcc void @jeandle.safepoint_poll()
+      [ "deopt"(i64 %sum, i32 %local) ]
+  %sum.next = add i64 %sum, %iv
+  %iv.next = add nuw nsw i64 %iv, 1
+  %done = icmp eq i64 %iv.next, %wide.limit
+  br i1 %done, label %exit, label %loop
+exit:
+  %result = phi i64 [ 0, %entry ], [ %sum.next, %loop ]
+  ret i64 %result
+}
+
+; CHECK-LABEL: @entry_inclusive(
+; CHECK:       loop.outer.inner.entry:
+; CHECK:         %local.outer = trunc nuw nsw i64 %outer.iv to i32
+; CHECK-NEXT:    call hotspotcc void @jeandle.safepoint_poll() #{{[0-9]+}}
+; CHECK-SAME:      [ "deopt"(i64 %sum.outer, i32 %local.outer) ]
+
+; Entry state alone is not a proof that a != exit is reachable without wrap.
+define void @unproven_ne(i64 noundef %limit) "java-method" {
+entry:
+  br label %loop
+loop:
+  %iv = phi i64 [ 1, %entry ], [ %iv.next, %loop ]
+  call hotspotcc void @jeandle.safepoint_poll() [ "deopt"(i64 %iv) ]
+  %iv.next = add i64 %iv, 1
+  %more = icmp ne i64 %iv.next, %limit
+  br i1 %more, label %loop, label %exit
+exit:
+  ret void
+}
+
+; CHECK-LABEL: @unproven_ne(
+; CHECK-NOT:     .outer
+; CHECK:         call hotspotcc void @jeandle.safepoint_poll() [ "deopt"(i64 %iv) ]
+; CHECK-NOT:     .outer
+; CHECK:       }
+
+!java-method-compilation = !{}

--- a/llvm/test/Jeandle/SafepointElimination/verify-strip-mined-poll-attribute.ll
+++ b/llvm/test/Jeandle/SafepointElimination/verify-strip-mined-poll-attribute.ll
@@ -55,6 +55,35 @@ exit:
   ret void
 }
 
+; Entry-state polls use the guarded per-batch inner preheader instead. Keep
+; the opaque clamp here so acceptance cannot come from a SCEV trip bound.
+define void @accepts_attributed_entry_nest(i64 %n) "java-method" {
+entry:
+  br label %outer.header
+outer.header:
+  %outer.iv = phi i64 [ 0, %entry ], [ %outer.iv.next, %outer.latch ]
+  %outer.cond = icmp slt i64 %outer.iv, %n
+  br i1 %outer.cond, label %inner.entry, label %exit
+inner.entry:
+  %batch.end = call i64 @llvm.sadd.sat.i64(i64 %outer.iv, i64 1000)
+  %cap.cond = icmp slt i64 %batch.end, %n
+  %inner.limit = select i1 %cap.cond, i64 %batch.end, i64 %n
+  call hotspotcc void @jeandle.safepoint_poll() #0 [ "deopt"(i64 %outer.iv) ]
+  br label %inner.header
+inner.header:
+  %iv = phi i64 [ %outer.iv, %inner.entry ], [ %iv.next, %inner.latch ]
+  br label %inner.latch
+inner.latch:
+  %iv.next = add nsw i64 %iv, 1
+  %inner.cond = icmp slt i64 %iv.next, %inner.limit
+  br i1 %inner.cond, label %inner.header, label %outer.latch
+outer.latch:
+  %outer.iv.next = phi i64 [ %iv.next, %inner.latch ]
+  br label %outer.header
+exit:
+  ret void
+}
+
 ; Same nest, but the outer latch poll lacks the attribute: nothing marks the
 ; inner loop as strip-mined, and its clamped trip count is opaque to SCEV, so
 ; it is reported uncovered.
@@ -172,10 +201,12 @@ exit:
 attributes #0 = { "jeandle.strip-mined-poll" }
 
 ; WARN-NOT:  accepts_attributed_nest
+; WARN-NOT:  accepts_attributed_entry_nest
 ; WARN:      'inner.header' in function 'rejects_unattributed_nest'
 ; WARN-NEXT: SafepointCoverageVerifier: loop with header 'inner.header' in function 'rejects_attribute_on_outer_header'
 ; WARN-NEXT: SafepointCoverageVerifier: loop with header 'outer.header' in function 'rejects_attribute_on_non_poll'
 ; WARN-NEXT: SafepointCoverageVerifier: loop with header 'inner.header' in function 'rejects_attribute_on_non_poll'
 
 ; ABORT-NOT: accepts_attributed_nest
+; ABORT-NOT: accepts_attributed_entry_nest
 ; ABORT:     Jeandle safepoint coverage verification failed


### PR DESCRIPTION
## Summary

Companion to jeandle/jeandle-jdk#609 (jeandle/jeandle-jdk#550).

Moving a conditional back-edge safepoint to its taken edge can cause loop rotation to place the poll at the loop header, with deoptimization operands describing the current header-entry PHIs. Strip mining currently rejects this valid entry state. JDK CI run [33374145438](https://github.com/jeandle/jeandle-jdk/actions/runs/33374145438) exposed this in both `TestStripMinedLoopShapes` configurations.

- Recognize header-entry polls conservatively: only PHIs, casts, and debug/pseudo instructions may precede the poll.
- Preserve entry PHI identity, including cast chains and swap recurrences, and reconstruct deoptimization values from current outer-loop PHIs at the guarded batch entry. Do not move entry-state polls to the final latch, where deoptimization could resume an extra iteration after the loop should exit.
- Retain existing rejection of mixed/current body states and memory-safety checks. Keep invariant-only cases on the existing path.
- Recognize strip-mined poll coverage at the per-batch inner preheader, constrained to the outer-header entry path.
- Apply SCEV loop guards when proving widened inclusive-loop bounds; continue rejecting unproven `!=` loops.
- Add regression coverage for entry PHIs/casts, swaps, widened inclusive bounds, unproven bounds, and the entry-poll coverage marker.

No JDK test assertions were changed or relaxed to resolve the failures.

## Validation

Based on LLVM `2d6e773ce770ccd2fec0f7d05eb8438b1d6f9914`, with JDK PR #609 at `c159fb41a8fa1d31db84a86c642300b7842d351f`, on Linux x64 via Docker on macOS:

- Reproduced both original `TestStripMinedLoopShapes.java#id0` and `#id1` failures with the exact CI Fastdebug bundle and original LLVM.
- The new LLVM regression fails with original LLVM.
- Safepoint lit suite using the source RUN/FileCheck directives: **105/105 passed** in Release and **105/105 passed** with assertions enabled.
- Targeted JDK suite (entire safepoint directory plus `TestUnstableIf`, `TestBranchWeights`, `TestSameTargetCondBr`, and `TestUnstableIfPruneBoundaries`): **17 passed / 8 debug-only configurations excluded** in Release; **25/25 passed** in Fastdebug, including both original failures.
- `git diff --check`: passed.

### Local build scope

This validation used an **incremental LLVM rebuild**, not a clean full-source CMake build: the two changed C++ translation units were rebuilt against matching CI headers/static archives, then the shared LLVM library was relinked. The opt driver and FileCheck were linked against the derived shared library to avoid testing the bundled statically linked opt. Temporary diagnostic instrumentation is not included in this patch or in the final tested library.

Full clean builds and broader integration validation are left to CI. Keeping this PR in draft while the paired JDK CI runs.
