### PR TITLE
feat: add late inline support to Jeandle inliner

### DIFF
--- a/llvm/include/llvm/IR/Jeandle/Metadata.h
+++ b/llvm/include/llvm/IR/Jeandle/Metadata.h
@@ -34,6 +34,8 @@ public:
 
   static constexpr const char *InlineScopeID = "inline-scope-id";
 
+  static constexpr const char *LateInline = "late-inline";
+
   // Set by inclusive loop versioning on the latch of the slow-path clone so the
   // later strip-mining pass skips it instead of trying to version it again.
   static constexpr const char *InclusiveSlowPath = "jeandle.inclusive.slow";

--- a/llvm/include/llvm/IR/Jeandle/VMCallback.h
+++ b/llvm/include/llvm/IR/Jeandle/VMCallback.h
@@ -74,6 +74,15 @@ enum class JeandleInlineReason : int {
   LLVMInlineFailed,
 };
 
+/// VM policy decision for an inline candidate. Keep the numeric values stable
+/// because callback logs and replay files persist them.
+enum class JeandleInlineDecision : int {
+  Deny = 0,
+  InlineNow,
+  InlineLater,
+  HitNodeCountCutoff,
+};
+
 // =============================================================================
 // Master callback list — add new callbacks here
 // =============================================================================
@@ -219,10 +228,10 @@ enum class JeandleInlineReason : int {
   def(IsKlassInitialized, bool, Bool,                                            \
       (uintptr_t a1), (a1),                                                      \
       (VMCallbackValueType::Uintptr), 1)                                         \
-  def(IsOkToInline, bool, Bool,                                                  \
-      (int a1, int a2, uintptr_t a3), (a1, a2, a3),                              \
+  def(GetInlineDecision, int, Int,                                               \
+      (int a1, int a2, uintptr_t a3, bool a4), (a1, a2, a3, a4),                 \
       (VMCallbackValueType::Int, VMCallbackValueType::Int,                       \
-       VMCallbackValueType::Uintptr), 3)                                         \
+       VMCallbackValueType::Uintptr, VMCallbackValueType::Bool), 4)               \
   def(GetInlineCalleeIR, bool, Bool,                                             \
       (uintptr_t a1), (a1),                                                      \
       (VMCallbackValueType::Uintptr), 1)                                         \
@@ -409,9 +418,9 @@ enum class JeandleInlineReason : int {
 ///                         instance klass. ConstantFieldFolding only acts on a
 ///                         true result because initialization is monotonic;
 ///                         false retains the dynamic initialization check.
-///   IsOkToInline        — Given an inline scope id, call-site BCI, and callee
-///                         Java method pointer, returns whether the VM allows
-///                         this inline attempt.
+///   GetInlineDecision   — Given an inline scope id, call-site BCI, callee Java
+///                         method pointer, and whether this is a late attempt,
+///                         returns a JeandleInlineDecision value.
 ///   GetInlineCalleeIR   — Given a callee Java method pointer, materializes its
 ///                         LLVM IR into the active module and returns whether
 ///                         the definition is available.

--- a/llvm/include/llvm/Transforms/Jeandle/JeandleInliner.h
+++ b/llvm/include/llvm/Transforms/Jeandle/JeandleInliner.h
@@ -13,7 +13,7 @@
 // the extension point for devirtualization refinement between inline rounds.
 // JeandleInliner handles the current inline step: it inlines Java method calls
 // where the callee may initially be a declaration, asks
-// VMCallbacks::IsOkToInline for policy, and uses
+// VMCallbacks::GetInlineDecision for policy, and uses
 // VMCallbacks::GetInlineCalleeIR to obtain callee IR on demand.
 //
 // The pass supports nested/transitive inlining: after a callee is inlined,
@@ -45,6 +45,8 @@ using JeandleInlineScope = std::pair<Function *, int>;
 struct InlineRoundResult {
   PreservedAnalyses PA = PreservedAnalyses::all();
   bool ExposedNewCallSites = false;
+  bool HasLateInlineCandidates = false;
+  bool HitNodeCountCutoff = false;
 };
 
 class JeandleInlineDriver : public PassInfoMixin<JeandleInlineDriver> {
@@ -65,7 +67,8 @@ public:
 
   InlineRoundResult
   runInlineRound(Module &M, ModuleAnalysisManager &MAM,
-                 SmallVectorImpl<JeandleInlineScope> &InlineScopes);
+                 SmallVectorImpl<JeandleInlineScope> &InlineScopes,
+                 bool InLateInlinePhase);
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
 
 private:

--- a/llvm/lib/Transforms/Jeandle/JeandleInlineDriver.cpp
+++ b/llvm/lib/Transforms/Jeandle/JeandleInlineDriver.cpp
@@ -59,16 +59,17 @@ using llvm::jeandle::getRootJavaMethodFunction;
 using llvm::jeandle::isJeandleJavaMethod;
 using llvm::jeandle::isRootJavaMethodFunction;
 
-static void eraseInlineScopeIDs(Function &RootFunction) {
+static void eraseInlineSchedulingMetadata(Function &RootFunction) {
   // inline-scope-id is private scheduling metadata produced and consumed only
   // by this driver. Removing it before returning does not change the program IR
   // seen by later passes, so it is intentionally not reported through
   // PreservedAnalyses.
   for (Instruction &I : instructions(RootFunction)) {
     auto *CB = dyn_cast<CallBase>(&I);
-    if (!CB || !CB->getMetadata(jeandle::Metadata::InlineScopeID))
+    if (!CB)
       continue;
     CB->setMetadata(jeandle::Metadata::InlineScopeID, nullptr);
+    CB->setMetadata(jeandle::Metadata::LateInline, nullptr);
   }
 }
 
@@ -166,6 +167,14 @@ static PreservedAnalyses runRootInstSimplify(Module &M,
   return RootPA;
 }
 
+static PreservedAnalyses runPreLateInlinePasses(Module &,
+                                                ModuleAnalysisManager &) {
+  // Java-specific elimination passes that need to see calls before late
+  // inlining should be added here. Keep this hook separate from the normal
+  // refinement loop so those passes run only immediately before a late round.
+  return PreservedAnalyses::all();
+}
+
 PreservedAnalyses JeandleInlineDriver::run(Module &M,
                                            ModuleAnalysisManager &MAM) {
   jeandle::registerInlineCalleeIRReplayMaterializer(
@@ -198,23 +207,34 @@ PreservedAnalyses JeandleInlineDriver::run(Module &M,
   // Loop shape:
   //   1. Run one inline round. The round tags every newly exposed call site
   //      with inline-scope-id metadata.
-  //   2. Per-round cleanup (runRootInstSimplify): lower the phase-0 JavaOp
-  //      calls exposed by this round and simplify the root. Runs even when the
-  //      round exposed no new *monomorphic* call sites, so a callee body that
-  //      only brought in phase-0 JavaOp calls still gets them lowered.
-  //   3. If the inline round did not expose any new call sites, stop.
-  //   4. Run devirtualization refinement. It must propagate inline-scope-id
+  //   2. A late round first runs Java-specific pre-late passes. Every changed
+  //      inline round then lowers newly exposed phase-0 JavaOps and simplifies
+  //      the root before refinement.
+  //   3. Eager rounds run until ordinary inlining reaches a fixed point. If
+  //      delayed candidates remain, the driver then enters the late phase.
+  //   4. The phase transition is one-way. Each late round processes markers
+  //   that
+  //      existed before its pre-late passes, and also handles ordinary calls
+  //      exposed by late inlining/refinement. A new InlineLater decision only
+  //      sets metadata, so that call cannot run until the next pre-late
+  //      boundary.
+  //   5. Run devirtualization refinement. It must propagate inline-scope-id
   //      and deopt/BCI information when it clones or replaces calls.
-  //   5. If devirtualization preserved everything, it did not produce a new
-  //      MonomorphicTarget call site and the loop stops; otherwise rescan IR
-  //      in the next inline round.
+  //   6. Late rounds repeat until neither refinement nor marked calls provide
+  //      more work.
   bool HitIterationLimit = true;
+  bool InLateInlinePhase = false;
   for (unsigned Iteration = 0; Iteration < MaxInlineDriverIterations;
        ++Iteration) {
 
-    // Inline one round.
+    if (InLateInlinePhase) {
+      PreservedAnalyses PreLatePA = runPreLateInlinePasses(M, MAM);
+      Changed |= !PreLatePA.areAllPreserved();
+      updateDriverPreservedAnalyses(M, MAM, DriverPA, std::move(PreLatePA));
+    }
+
     InlineRoundResult InlineResult =
-        Inliner.runInlineRound(M, MAM, InlineScopes);
+        Inliner.runInlineRound(M, MAM, InlineScopes, InLateInlinePhase);
     bool RoundChanged = !InlineResult.PA.areAllPreserved();
     Changed |= RoundChanged;
 
@@ -222,8 +242,7 @@ PreservedAnalyses JeandleInlineDriver::run(Module &M,
       updateDriverPreservedAnalyses(M, MAM, DriverPA,
                                     std::move(InlineResult.PA));
 
-      // Lower phase-0 JavaOp call sites exposed by the previous inline round's
-      // inlining.
+      // Lower phase-0 JavaOp call sites exposed by this inline round.
       PreservedAnalyses JavaOpLowerPA = JavaOperationLower(0).run(M, MAM);
       Changed |= !JavaOpLowerPA.areAllPreserved();
       updateDriverPreservedAnalyses(M, MAM, DriverPA, std::move(JavaOpLowerPA));
@@ -235,8 +254,17 @@ PreservedAnalyses JeandleInlineDriver::run(Module &M,
     }
 
     if (!InlineResult.ExposedNewCallSites) {
-      HitIterationLimit = false;
-      break;
+      if (InlineResult.HasLateInlineCandidates) {
+        // This assignment is intentionally monotonic. Once eager inlining has
+        // stopped making progress, the driver stays in the late scheduling
+        // phase. Each call's marker still decides whether its VM query uses
+        // the late policy.
+        InLateInlinePhase = true;
+        continue;
+      } else {
+        HitIterationLimit = false;
+        break;
+      }
     }
 
     FunctionAnalysisManager &FAM =
@@ -255,14 +283,27 @@ PreservedAnalyses JeandleInlineDriver::run(Module &M,
     DevirtModulePA.preserve<FunctionAnalysisManagerModuleProxy>();
     updateDriverPreservedAnalyses(M, MAM, DriverPA, std::move(DevirtModulePA));
 
-    // Devirtualization may rewrite the root IR and replace CallBase objects
-    // exposed by the inline round. Do not carry a cross-step worklist through
-    // this point; the next inline round rescans the root function and should
-    // read the preserved inline-scope-id metadata from surviving/generated call
-    // sites.
+    if (InlineResult.HitNodeCountCutoff) {
+      if (InLateInlinePhase || !InlineResult.HasLateInlineCandidates) {
+        HitIterationLimit = false;
+        break;
+      }
+
+      InLateInlinePhase = true;
+      continue;
+    }
+
     if (!AddedMonomorphicTargets) {
-      HitIterationLimit = false;
-      break;
+      if (!InlineResult.HasLateInlineCandidates) {
+        HitIterationLimit = false;
+        break;
+      }
+
+      // Refinement produced no ordinary eager work, so the delayed candidates
+      // are now the only remaining source of progress. This assignment either
+      // performs the one-way eager-to-late transition or keeps an existing late
+      // phase active; it never returns the driver to eager inlining.
+      InLateInlinePhase = true;
     }
   }
 
@@ -274,19 +315,19 @@ PreservedAnalyses JeandleInlineDriver::run(Module &M,
                          "inline/devirtualization convergence.\n");
   }
 
-  if (!Changed)
-    return PreservedAnalyses::all();
-
-  FunctionAnalysisManager &FAM =
-      MAM.getResult<FunctionAnalysisManagerModuleProxy>(M).getManager();
-
   // inline-scope-id is driver-local scheduling state. It is only needed while
   // the driver loop is active so devirtualization rewrites can preserve scope
   // IDs for the next inline round. Drop it before leaving the driver to avoid
   // leaking stale scope IDs into later optimizations or a future driver
   // invocation.
   if (RootFunction)
-    eraseInlineScopeIDs(*RootFunction);
+    eraseInlineSchedulingMetadata(*RootFunction);
+
+  if (!Changed)
+    return PreservedAnalyses::all();
+
+  FunctionAnalysisManager &FAM =
+      MAM.getResult<FunctionAnalysisManagerModuleProxy>(M).getManager();
 
   // Notify the VM before available_externally callee bodies are removed. The
   // JVM uses this point to snapshot a replay side module containing the IR

--- a/llvm/lib/Transforms/Jeandle/JeandleInliner.cpp
+++ b/llvm/lib/Transforms/Jeandle/JeandleInliner.cpp
@@ -572,6 +572,11 @@ InlineRoundResult JeandleInliner::runInlineRound(
       continue;
     }
 
+    // Jeandle's inline policy consumes JVM profile through VM callbacks, while
+    // imported inlinees have no LLVM function entry counts. Branch/switch
+    // profile metadata is cloned with the IR, and caller analyses are
+    // invalidated after each inline, so profile redistribution and BFI
+    // maintenance are unnecessary here.
     InlineFunctionInfo IFI(GetAssumptionCache, /*PSI=*/nullptr,
                            /*CallerBFI=*/nullptr, /*CalleeBFI=*/nullptr,
                            /*UpdateProfile=*/false);

--- a/llvm/lib/Transforms/Jeandle/JeandleInliner.cpp
+++ b/llvm/lib/Transforms/Jeandle/JeandleInliner.cpp
@@ -25,7 +25,9 @@
 //      site has the llvm::jeandle::Attribute::MonomorphicTarget attribute.
 //      In accessor-only mode, the callee must also have the
 //      llvm::jeandle::Attribute::JavaAccessorMethod function attribute.
-//   2. For each call site, ask VMCallbacks::IsOkToInline whether to inline.
+//   2. For each call site, ask VMCallbacks::GetInlineDecision whether to
+//      inline now, mark it for a later round, reject it, or report that the
+//      node-count cutoff was reached.
 //   3. If the callee is a declaration, call VMCallbacks::GetInlineCalleeIR to
 //      obtain its IR definition.
 //   4. Inline the call site using InlineFunction.
@@ -60,7 +62,6 @@
 #include "llvm/Analysis/AssumptionCache.h"
 #include "llvm/Analysis/InlineCost.h"
 #include "llvm/Analysis/OptimizationRemarkEmitter.h"
-#include "llvm/Analysis/ProfileSummaryInfo.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/GlobalAlias.h"
 #include "llvm/IR/GlobalObject.h"
@@ -126,12 +127,32 @@ static PreservedAnalyses getInlineRoundPreservedAnalyses(bool Changed) {
   return PA;
 }
 
-static InlineRoundResult makeInlineRoundResult(bool Changed,
-                                               bool ExposedNewCallSites) {
+static InlineRoundResult
+makeInlineRoundResult(bool Changed, bool ExposedNewCallSites,
+                      bool HasLateInlineCandidates = false,
+                      bool HitNodeCountCutoff = false) {
   InlineRoundResult Result;
   Result.PA = getInlineRoundPreservedAnalyses(Changed);
   Result.ExposedNewCallSites = ExposedNewCallSites;
+  Result.HasLateInlineCandidates = HasLateInlineCandidates;
+  Result.HitNodeCountCutoff = HitNodeCountCutoff;
   return Result;
+}
+
+static bool hasLateInlineMarker(const CallBase &CB) {
+  return CB.getMetadata(jeandle::Metadata::LateInline) != nullptr;
+}
+
+static void setLateInlineMarker(CallBase &CB, bool Marked) {
+  CB.setMetadata(jeandle::Metadata::LateInline,
+                 Marked ? MDNode::get(CB.getContext(), {}) : nullptr);
+}
+
+static void clearLateInlineMarkers(Function &F) {
+  for (Instruction &I : instructions(F)) {
+    if (auto *CB = dyn_cast<CallBase>(&I))
+      setLateInlineMarker(*CB, false);
+  }
 }
 
 static void setInlineScopeID(CallBase &CB, int InlineScopeID) {
@@ -332,7 +353,7 @@ static void recordInlineResult(const jeandle::VMCallbacks &VC,
 
 InlineRoundResult JeandleInliner::runInlineRound(
     Module &M, ModuleAnalysisManager &MAM,
-    SmallVectorImpl<JeandleInlineScope> &InlineScopes) {
+    SmallVectorImpl<JeandleInlineScope> &InlineScopes, bool InLateInlinePhase) {
   if (!M.getNamedMetadata(jeandle::Metadata::JavaMethodCompilation)) {
     return makeInlineRoundResult(/*Changed=*/false,
                                  /*ExposedNewCallSites=*/false);
@@ -344,9 +365,9 @@ InlineRoundResult JeandleInliner::runInlineRound(
     return makeInlineRoundResult(/*Changed=*/false,
                                  /*ExposedNewCallSites=*/false);
   }
-  if (!VC->IsOkToInline) {
+  if (!VC->GetInlineDecision) {
     LLVM_DEBUG(
-        dbgs() << "JeandleInliner: no IsOkToInline callback, skipping\n");
+        dbgs() << "JeandleInliner: no GetInlineDecision callback, skipping\n");
     return makeInlineRoundResult(/*Changed=*/false,
                                  /*ExposedNewCallSites=*/false);
   }
@@ -371,7 +392,6 @@ InlineRoundResult JeandleInliner::runInlineRound(
 
   FunctionAnalysisManager &FAM =
       MAM.getResult<FunctionAnalysisManagerModuleProxy>(M).getManager();
-  auto &PSI = MAM.getResult<ProfileSummaryAnalysis>(M);
 
   auto GetAAR = [&](Function &F) -> AAResults & {
     return FAM.getResult<AAManager>(F);
@@ -380,18 +400,31 @@ InlineRoundResult JeandleInliner::runInlineRound(
     return FAM.getResult<AssumptionAnalysis>(F);
   };
 
+  SmallVector<std::pair<CallBase *, int>, 16> RootCallSites;
   SmallVector<std::pair<CallBase *, int>, 16> Worklist;
+  // Snapshot every CallBase currently in the root function. After each
+  // successful inline, pointer-set differencing identifies calls cloned from
+  // the callee.
   SmallPtrSet<const CallBase *, 32> KnownCallSites;
   Function *RootFunction = getRootJavaMethodFunction(M);
   if (!RootFunction)
     return makeInlineRoundResult(/*Changed=*/false,
                                  /*ExposedNewCallSites=*/false);
 
+  bool HasLateInlineCandidates = false;
+
   for (Instruction &I : instructions(RootFunction)) {
     auto *CB = dyn_cast<CallBase>(&I);
     if (!CB)
       continue;
     KnownCallSites.insert(CB);
+
+    bool IsLateInline = hasLateInlineMarker(*CB);
+    if (IsLateInline && !InLateInlinePhase) {
+      HasLateInlineCandidates = true;
+      continue;
+    }
+
     Function *Callee = CB->getCalledFunction();
     if (!Callee || !isEligibleInlineCallee(*Callee, InlineAccessorsOnly))
       continue;
@@ -399,22 +432,46 @@ InlineRoundResult JeandleInliner::runInlineRound(
       continue;
     if (CB->isNoInline())
       continue;
-    Worklist.push_back({CB, getInlineScopeID(*CB)});
+    RootCallSites.push_back({CB, getInlineScopeID(*CB)});
   }
+
+  // Worklist is consumed from the back. RootCallSites records the desired
+  // processing order in root IR order. Reverse it when initializing the LIFO
+  // worklist so pop_back_val() observes that order while newly exposed children
+  // can still be pushed above unprocessed siblings.
+  for (auto It = RootCallSites.rbegin(), E = RootCallSites.rend(); It != E;
+       ++It)
+    Worklist.push_back(*It);
 
   uint64_t ThreadID = llvm::get_threadid();
   logPassBoundary("begin", *RootFunction, ThreadID);
 
   bool Changed = false;
   bool ExposedNewCallSites = false;
+  bool HitNodeCountCutoff = false;
 
-  for (unsigned I = 0; I < Worklist.size(); ++I) {
-    CallBase *CB = Worklist[I].first;
-    int InlineScopeID = Worklist[I].second;
+  auto MarkNoInline = [&](CallBase &CB) {
+    if (CB.isNoInline())
+      return;
+    CB.setIsNoInline();
+    Changed = true;
+  };
+
+  // A late marker is sticky. If LLVM cannot complete an InlineNow decision,
+  // make the surviving call terminal so a later round cannot retry forever.
+  auto PreventLateInlineRetry = [&](CallBase &CB, bool IsLateInline) {
+    if (!IsLateInline)
+      return;
+    MarkNoInline(CB);
+  };
+
+  while (!Worklist.empty()) {
+    auto [CB, InlineScopeID] = Worklist.pop_back_val();
 
     if (!CB || !CB->getCaller())
       continue;
 
+    bool IsLateInline = hasLateInlineMarker(*CB);
     Function *Caller = CB->getCaller();
     Function *Callee = CB->getCalledFunction();
 
@@ -437,19 +494,44 @@ InlineRoundResult JeandleInliner::runInlineRound(
     // caller's landingpad. Mark root callees noinline so later LLVM inline
     // passes cannot inline them either.
     if (CalleeMethod == getJavaMethodPointer(*RootFunction)) {
-      CB->setIsNoInline();
+      MarkNoInline(*CB);
       recordInlineResult(*VC, InlineScopeID, BCI, CalleeMethod,
                          jeandle::JeandleInlineReason::RootCalleeUnsupported);
       continue;
     }
 
-    bool IsOkToInline = VC->IsOkToInline(InlineScopeID, BCI, CalleeMethod);
-
-    if (!IsOkToInline) {
+    int RawDecision =
+        VC->GetInlineDecision(InlineScopeID, BCI, CalleeMethod, IsLateInline);
+    auto Decision = static_cast<jeandle::JeandleInlineDecision>(RawDecision);
+    if (Decision == jeandle::JeandleInlineDecision::HitNodeCountCutoff) {
+      logInlineEvent("node-count-cutoff", ScopeCaller, BCI, Callee,
+                     InlineScopeID, ThreadID, InlineScopes);
+      HitNodeCountCutoff = true;
+      if (InLateInlinePhase) {
+        HasLateInlineCandidates = false;
+      }
+      break;
+    }
+    if (Decision == jeandle::JeandleInlineDecision::Deny) {
+      if (IsLateInline)
+        MarkNoInline(*CB);
       logInlineEvent("no-inline", ScopeCaller, BCI, Callee, InlineScopeID,
                      ThreadID, InlineScopes);
       continue;
     }
+    if (Decision == jeandle::JeandleInlineDecision::InlineLater) {
+      assert(!IsLateInline && "VM delayed a late-inline candidate again");
+      // Do not reinsert this call into the current worklist. Its marker is
+      // discovered only by the next round, after runPreLateInlinePasses has
+      // run.
+      setLateInlineMarker(*CB, true);
+      HasLateInlineCandidates = true;
+      logInlineEvent("late-inline", ScopeCaller, BCI, Callee, InlineScopeID,
+                     ThreadID, InlineScopes);
+      continue;
+    }
+    assert(Decision == jeandle::JeandleInlineDecision::InlineNow &&
+           "invalid inline decision");
 
     if (Callee->isDeclaration()) {
       logInlineEvent("request-ir", ScopeCaller, BCI, Callee, InlineScopeID,
@@ -458,6 +540,7 @@ InlineRoundResult JeandleInliner::runInlineRound(
       if (!GotCalleeIR) {
         logInlineEvent("missing-ir", ScopeCaller, BCI, Callee, InlineScopeID,
                        ThreadID, InlineScopes);
+        PreventLateInlineRetry(*CB, IsLateInline);
         recordInlineResult(
             *VC, InlineScopeID, BCI, CalleeMethod,
             jeandle::JeandleInlineReason::GetInlineCalleeIRFailed);
@@ -467,6 +550,7 @@ InlineRoundResult JeandleInliner::runInlineRound(
       if (Callee->isDeclaration()) {
         logInlineEvent("missing-def", ScopeCaller, BCI, Callee, InlineScopeID,
                        ThreadID, InlineScopes);
+        PreventLateInlineRetry(*CB, IsLateInline);
         recordInlineResult(
             *VC, InlineScopeID, BCI, CalleeMethod,
             jeandle::JeandleInlineReason::MissingInlineCalleeDefinition);
@@ -482,14 +566,15 @@ InlineRoundResult JeandleInliner::runInlineRound(
                         << ScopeCaller->getName() << " @" << BCI << " -> "
                         << Callee->getName() << ": "
                         << inlineResult.getFailureReason() << "\n");
+      PreventLateInlineRetry(*CB, IsLateInline);
       recordInlineResult(*VC, InlineScopeID, BCI, CalleeMethod,
                          jeandle::JeandleInlineReason::NotInlineViable);
       continue;
     }
 
-    InlineFunctionInfo IFI(GetAssumptionCache, &PSI,
-                           &FAM.getResult<BlockFrequencyAnalysis>(*Caller),
-                           &FAM.getResult<BlockFrequencyAnalysis>(*Callee));
+    InlineFunctionInfo IFI(GetAssumptionCache, /*PSI=*/nullptr,
+                           /*CallerBFI=*/nullptr, /*CalleeBFI=*/nullptr,
+                           /*UpdateProfile=*/false);
 
     InlineResult IR = InlineFunction(*CB, IFI, /*MergeAttributes=*/true,
                                      &GetAAR(*Caller), /*InsertLifetime=*/true);
@@ -500,6 +585,7 @@ InlineRoundResult JeandleInliner::runInlineRound(
                         << ScopeCaller->getName() << " @" << BCI << " -> "
                         << Callee->getName() << ": " << IR.getFailureReason()
                         << "\n");
+      PreventLateInlineRetry(*CB, IsLateInline);
       recordInlineResult(*VC, InlineScopeID, BCI, CalleeMethod,
                          jeandle::JeandleInlineReason::LLVMInlineFailed);
       continue;
@@ -556,8 +642,12 @@ InlineRoundResult JeandleInliner::runInlineRound(
         continue;
       NewCallSites.push_back(NewCB);
     }
+    // Replace the snapshot after every inline. Calls exposed by this inline are
+    // new now, but must be considered known when a later inline in this round
+    // performs the same comparison.
     KnownCallSites = std::move(CurrentCallSites);
 
+    SmallVector<std::pair<CallBase *, int>, 8> NewWorkItems;
     for (CallBase *NewCB : NewCallSites) {
       // Statepoint ids in callee IR belong to the original template call sites.
       // Every inlined copy must get a fresh JVM-side id so updating its
@@ -565,6 +655,10 @@ InlineRoundResult JeandleInliner::runInlineRound(
       ensureUniqueStatepointID(*NewCB, *VC);
       setInlineScopeID(*NewCB, NewScopeID);
       ExposedNewCallSites = true;
+
+      // InlineFunction copies the marker from a delayed call in the inlinee.
+      // Keep it: pre-late passes have already run before this late round, so
+      // the cloned call retains the same late-inline policy.
 
       Function *NewCallee = NewCB->getCalledFunction();
       // TODO: Support inlining the root method as a callee once root/caller IR
@@ -582,17 +676,63 @@ InlineRoundResult JeandleInliner::runInlineRound(
           !isEligibleInlineCallee(*NewCallee, InlineAccessorsOnly) ||
           !isMonomorphicTargetCall(*NewCB) || NewCB->isNoInline())
         continue;
-      Worklist.push_back({NewCB, NewScopeID});
+      NewWorkItems.push_back({NewCB, NewScopeID});
     }
+
+    // Push children in reverse IR order. They sit above every unprocessed
+    // sibling already in the LIFO worklist, so the next pop descends into the
+    // just-inlined scope while preserving IR order among its children. The same
+    // rule applies in eager and late rounds.
+    for (auto It = NewWorkItems.rbegin(), E = NewWorkItems.rend(); It != E;
+         ++It)
+      Worklist.push_back(*It);
   }
 
   logPassBoundary("end", *RootFunction, ThreadID);
-  return makeInlineRoundResult(Changed, ExposedNewCallSites);
+  return makeInlineRoundResult(Changed, ExposedNewCallSites,
+                               HasLateInlineCandidates, HitNodeCountCutoff);
 }
 
 PreservedAnalyses JeandleInliner::run(Module &M, ModuleAnalysisManager &MAM) {
   SmallVector<JeandleInlineScope, 16> InlineScopes;
-  return runInlineRound(M, MAM, InlineScopes).PA;
+  PreservedAnalyses PA = PreservedAnalyses::all();
+  bool InLateInlinePhase = false;
+  bool UsedLateInlineScheduling = false;
+
+  // Keep the standalone pass consistent with JeandleInlineDriver: eager
+  // inlining reaches a fixed point first, then a single one-way transition
+  // enters the late phase. Once there, every later round keeps the global late
+  // scheduling phase. Individual calls still enter the VM's late policy only
+  // after their marker survives one pre-late boundary.
+  for (;;) {
+    InlineRoundResult Result =
+        runInlineRound(M, MAM, InlineScopes, InLateInlinePhase);
+    PA.intersect(std::move(Result.PA));
+
+    if (Result.HitNodeCountCutoff) {
+      if (InLateInlinePhase || !Result.HasLateInlineCandidates)
+        break;
+      InLateInlinePhase = true;
+      UsedLateInlineScheduling = true;
+      continue;
+    }
+
+    if (Result.ExposedNewCallSites)
+      continue;
+    if (!Result.HasLateInlineCandidates)
+      break;
+
+    // This is the standalone entry point's only phase transition. Subsequent
+    // iterations leave InLateInlinePhase set even when a round exposes normal
+    // monomorphic calls rather than another explicitly delayed candidate.
+    InLateInlinePhase = true;
+    UsedLateInlineScheduling = true;
+  }
+  if (UsedLateInlineScheduling) {
+    if (Function *RootFunction = getRootJavaMethodFunction(M))
+      clearLateInlineMarkers(*RootFunction);
+  }
+  return PA;
 }
 
 /* ------------- Inline callee replay support begin ------------- */

--- a/llvm/test/Jeandle/inline/Inputs/exception-handling.cblog
+++ b/llvm/test/Jeandle/inline/Inputs/exception-handling.cblog
@@ -1,4 +1,4 @@
-IsOkToInline -1 7 103 = true
+GetInlineDecision -1 7 103 false = 1
 GetInlineCalleeIR 103 = true
 RecordInlineResult -1 7 103 0 = true
 RecordInliningComplete = true

--- a/llvm/test/Jeandle/inline/Inputs/global-alias.cblog
+++ b/llvm/test/Jeandle/inline/Inputs/global-alias.cblog
@@ -1,4 +1,4 @@
-IsOkToInline -1 3 102 = true
+GetInlineDecision -1 3 102 false = 1
 GetInlineCalleeIR 102 = true
 RecordInlineResult -1 3 102 0 = true
 RecordInliningComplete = true

--- a/llvm/test/Jeandle/inline/Inputs/global-variable.cblog
+++ b/llvm/test/Jeandle/inline/Inputs/global-variable.cblog
@@ -1,4 +1,4 @@
-IsOkToInline -1 0 101 = true
+GetInlineDecision -1 0 101 false = 1
 GetInlineCalleeIR 101 = true
 RecordInlineResult -1 0 101 0 = true
 RecordInliningComplete = true

--- a/llvm/test/Jeandle/inline/Inputs/javaop-lowering-in-driver.cblog
+++ b/llvm/test/Jeandle/inline/Inputs/javaop-lowering-in-driver.cblog
@@ -1,4 +1,4 @@
-IsOkToInline -1 0 101 = true
+GetInlineDecision -1 0 101 false = 1
 GetInlineCalleeIR 101 = true
 RecordInlineResult -1 0 101 0 = true
 RecordInliningComplete = true

--- a/llvm/test/Jeandle/inline/Inputs/late-inline-failure.cblog
+++ b/llvm/test/Jeandle/inline/Inputs/late-inline-failure.cblog
@@ -1,0 +1,5 @@
+GetInlineDecision -1 7 104 false = 2
+GetInlineDecision -1 7 104 true = 1
+GetInlineCalleeIR 104 = false
+RecordInlineResult -1 7 104 2 = true
+RecordInliningComplete = true

--- a/llvm/test/Jeandle/inline/Inputs/late-inline.cblog
+++ b/llvm/test/Jeandle/inline/Inputs/late-inline.cblog
@@ -1,0 +1,9 @@
+GetInlineDecision -1 7 104 false = 2
+GetInlineDecision -1 7 104 true = 1
+GetInlineDecision 0 11 105 false = 2
+GetInlineDecision 0 11 105 true = 1
+GetInlineCalleeIR 104 = true
+GetInlineCalleeIR 105 = true
+RecordInlineResult -1 7 104 0 = true
+RecordInlineResult 0 11 105 0 = true
+RecordInliningComplete = true

--- a/llvm/test/Jeandle/inline/Inputs/late-inline_inline_callees.ll
+++ b/llvm/test/Jeandle/inline/Inputs/late-inline_inline_callees.ll
@@ -1,0 +1,19 @@
+@jeandle.personality = global ptr null
+
+define available_externally hotspotcc i32 @late_callee() #0 gc "hotspotgc" personality ptr @jeandle.personality {
+entry:
+  %OrigPcSlot = alloca i64, align 8
+  %result = call hotspotcc i32 @late_child() #2 [ "deopt"(i32 11, i32 11, i64 327695, ptr %OrigPcSlot) ]
+  ret i32 %result
+}
+
+define available_externally hotspotcc i32 @late_child() #1 gc "hotspotgc" personality ptr @jeandle.personality {
+entry:
+  ret i32 42
+}
+
+attributes #0 = { "java-method"="104" }
+attributes #1 = { "java-method"="105" }
+attributes #2 = { "monomorphic-target" }
+
+!java-method-compilation = !{}

--- a/llvm/test/Jeandle/inline/Inputs/policy-denied.cblog
+++ b/llvm/test/Jeandle/inline/Inputs/policy-denied.cblog
@@ -1,1 +1,1 @@
-IsOkToInline -1 11 104 = false
+GetInlineDecision -1 11 104 false = 0

--- a/llvm/test/Jeandle/inline/Inputs/resume.cblog
+++ b/llvm/test/Jeandle/inline/Inputs/resume.cblog
@@ -1,5 +1,5 @@
-IsOkToInline -1 13 105 = true
-IsOkToInline -1 17 106 = true
+GetInlineDecision -1 13 105 false = 1
+GetInlineDecision -1 17 106 false = 1
 GetInlineCalleeIR 105 = true
 GetInlineCalleeIR 106 = true
 RecordInlineResult -1 13 105 0 = true

--- a/llvm/test/Jeandle/inline/Inputs/statepoint-id.cblog
+++ b/llvm/test/Jeandle/inline/Inputs/statepoint-id.cblog
@@ -1,5 +1,5 @@
-IsOkToInline -1 5 108 = true
-IsOkToInline -1 9 109 = true
+GetInlineDecision -1 5 108 false = 1
+GetInlineDecision -1 9 109 false = 1
 GetInlineCalleeIR 108 = true
 GetInlineCalleeIR 109 = true
 RecordInlineResult -1 5 108 0 = true

--- a/llvm/test/Jeandle/inline/late-inline-failure.ll
+++ b/llvm/test/Jeandle/inline/late-inline-failure.ll
@@ -1,0 +1,26 @@
+; RUN: opt -S -passes=jeandle-inline-driver -jeandle-vm-callback-log=%S/Inputs/late-inline-failure.cblog %s 2>&1 | FileCheck %s
+
+; A late-inline call that cannot be inlined must become noinline. Its marker is
+; sticky during the driver, so leaving the call eligible would retry the same
+; terminal failure in every later round.
+
+@jeandle.personality = global ptr null
+
+define hotspotcc i32 @root() #0 gc "hotspotgc" personality ptr @jeandle.personality {
+entry:
+  %OrigPcSlot = alloca i64, align 8
+  %result = call hotspotcc i32 @late_callee() #2 [ "deopt"(i32 7, i32 7, i64 327695, ptr %OrigPcSlot) ]
+  ret i32 %result
+}
+
+declare hotspotcc i32 @late_callee() #1 gc "hotspotgc"
+
+attributes #0 = { "java-method"="4" }
+attributes #1 = { "java-method"="104" }
+attributes #2 = { "monomorphic-target" }
+
+!java-method-compilation = !{}
+
+; CHECK-LABEL: define hotspotcc i32 @root(
+; CHECK: call hotspotcc i32 @late_callee() #[[CALL_ATTRS:[0-9]+]]
+; CHECK: attributes #[[CALL_ATTRS]] = { noinline "monomorphic-target" }

--- a/llvm/test/Jeandle/inline/late-inline.ll
+++ b/llvm/test/Jeandle/inline/late-inline.ll
@@ -1,0 +1,35 @@
+; RUN: opt -S -passes=jeandle-inline-driver -jeandle-vm-callback-log=%S/Inputs/late-inline.cblog %s 2>&1 | FileCheck %s
+
+; The eager policy defers this call. The first late round processes the delayed
+; callee, but its newly exposed ordinary child is queried with
+; is_late_inline=false and delayed. A second late round processes that child
+; only after another pre-late cleanup opportunity.
+
+@jeandle.personality = global ptr null
+
+define hotspotcc i32 @root() #0 gc "hotspotgc" personality ptr @jeandle.personality {
+entry:
+  %OrigPcSlot = alloca i64, align 8
+  %result = call hotspotcc i32 @late_callee() #2 [ "deopt"(i32 7, i32 7, i64 327695, ptr %OrigPcSlot) ]
+  ret i32 %result
+}
+
+declare hotspotcc i32 @late_callee() #1 gc "hotspotgc"
+declare hotspotcc i32 @late_child() #3 gc "hotspotgc"
+
+attributes #0 = { "java-method"="4" }
+attributes #1 = { "java-method"="104" }
+attributes #2 = { "monomorphic-target" }
+attributes #3 = { "java-method"="105" }
+
+!java-method-compilation = !{}
+!static-call-patch-size = !{!0}
+
+!0 = !{i32 5}
+
+; CHECK-LABEL: define hotspotcc i32 @root(
+; CHECK-NOT: call hotspotcc i32 @late_callee
+; CHECK-NOT: call hotspotcc i32 @late_child
+; CHECK: ret i32 42
+; CHECK-NOT: define available_externally hotspotcc i32 @late_callee
+; CHECK-NOT: define available_externally hotspotcc i32 @late_child


### PR DESCRIPTION
## Related issue(s):

issue #106 

## What this PR does / why we need it:

Replace IsOkToInline with GetInlineDecision to support eager, delayed,
denied, and node-count-cutoff decisions.

Add one-way eager-to-late scheduling and depth-first inline processing.
Preserve inline scope metadata across rounds, prevent failed late-inline
candidates from being retried, and correctly invalidate analyses when
adding noinline attributes.

Update callback replay logs and add tests for successful and failed
late inlining.